### PR TITLE
Ensure that Slice can only operate on native byte-order buffers

### DIFF
--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -34,6 +34,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -87,6 +88,7 @@ public final class Slice
     {
         checkNotNull(byteBuffer, "byteBuffer is null");
         checkArgument(byteBuffer instanceof DirectBuffer, "byteBuffer is not an instance of %s", DirectBuffer.class.getName());
+        checkArgument(ByteOrder.nativeOrder().equals(byteBuffer.order()), "byteBuffer is byte order %s, must be native order %s", byteBuffer.order(), ByteOrder.nativeOrder());
         DirectBuffer directBuffer = (DirectBuffer) byteBuffer;
         long address = directBuffer.address();
         int capacity = byteBuffer.capacity();

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -59,6 +59,10 @@ public final class Slice
     private static final MethodHandle newByteBuffer;
 
     static {
+        if (!ByteOrder.LITTLE_ENDIAN.equals(ByteOrder.nativeOrder())) {
+            throw new UnsupportedOperationException("Slice currently only supports little endian machines.  " +
+                    "This restriction may be relaxed in a future release.");
+        }
         try {
             // fetch theUnsafe object
             Field field = Unsafe.class.getDeclaredField("theUnsafe");

--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -18,6 +18,7 @@ import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
@@ -35,7 +36,7 @@ public final class Slices
     public static Slice mapFileReadOnly(File file)
             throws IOException
     {
-        return Slice.toUnsafeSlice(Files.map(file));
+        return Slice.toUnsafeSlice(Files.map(file).order(ByteOrder.nativeOrder()));
     }
 
     /**

--- a/src/test/java/io/airlift/slice/TestByteOrder.java
+++ b/src/test/java/io/airlift/slice/TestByteOrder.java
@@ -16,15 +16,20 @@ package io.airlift.slice;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-public class TestDirectSlice
-        extends TestSlice
+import org.testng.annotations.Test;
+
+public class TestByteOrder
 {
-    @Override
-    protected Slice allocate(int size)
+    @Test
+    public void testCorrectOrder() throws Exception
     {
-        if (size == 0) {
-            return Slices.EMPTY_SLICE;
-        }
-        return Slice.toUnsafeSlice(ByteBuffer.allocateDirect(size).order(ByteOrder.nativeOrder()));
+        Slice.toUnsafeSlice(ByteBuffer.allocateDirect(100).order(ByteOrder.nativeOrder()));
+    }
+
+    @Test(expectedExceptions = { IllegalArgumentException.class } )
+    public void testWrongOrder() throws Exception
+    {
+        ByteOrder order = ByteOrder.BIG_ENDIAN.equals(ByteOrder.nativeOrder()) ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
+        Slice.toUnsafeSlice(ByteBuffer.allocateDirect(100).order(order));
     }
 }


### PR DESCRIPTION
Currently, Slice is interoperable with `ByteBuffer` instances as long as the order matches.  Slice uses `Unsafe` which is always native byte order, whereas `ByteBuffer` may be swapped.

The default `ByteBuffer` factories produce big endian buffers, whereas most users will be on little endian platforms.  This is extremely surprising when all of your buffers are suddenly byte swapped!

Unfortunately this is a breaking change as all consumers will now have to specify a byte order.  I am not sure if this is the best fix, maybe there is something that can be done which is less breaking...
