### PR TITLE
Convert index checks to assert, giving a significant speed boost.

### DIFF
--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -940,6 +940,6 @@ public final class Slice
 
     private void checkIndexLength(int index, int length)
     {
-        checkPositionIndexes(index, index + length, length());
+        assert index >= 0 && length >= 0 && index + length <= length() : index + " bytes " + length + " length is out of bounds: " + length();
     }
 }

--- a/src/test/java/io/airlift/slice/TestSlice.java
+++ b/src/test/java/io/airlift/slice/TestSlice.java
@@ -128,29 +128,29 @@ public class TestSlice
                 try {
                     //noinspection ResultOfMethodCallIgnored
                     slice.equals(0, size, EMPTY_SLICE, 0, size);
-                    fail("expected IndexOutOfBoundsException");
+                    fail("expected AssertionError");
                 }
-                catch (IndexOutOfBoundsException expected) {
+                catch (AssertionError expected) {
                 }
                 try {
                     //noinspection ResultOfMethodCallIgnored
                     EMPTY_SLICE.equals(0, size, slice, 0, size);
-                    fail("expected IndexOutOfBoundsException");
+                    fail("expected AssertionError");
                 }
-                catch (IndexOutOfBoundsException expected) {
+                catch (AssertionError expected) {
                 }
 
                 try {
                     slice.compareTo(0, size, EMPTY_SLICE, 0, size);
-                    fail("expected IndexOutOfBoundsException");
+                    fail("expected AssertionError");
                 }
-                catch (IndexOutOfBoundsException expected) {
+                catch (AssertionError expected) {
                 }
                 try {
                     EMPTY_SLICE.compareTo(0, size, slice, 0, size);
-                    fail("expected IndexOutOfBoundsException");
+                    fail("expected AssertionError");
                 }
-                catch (IndexOutOfBoundsException expected) {
+                catch (AssertionError expected) {
                 }
             }
         }
@@ -249,30 +249,30 @@ public class TestSlice
 
         try {
             slice.getByte(-1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getByte((slice.length() - SIZE_OF_BYTE) + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getByte(slice.length());
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getByte(slice.length() + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
     }
 
@@ -297,30 +297,30 @@ public class TestSlice
 
         try {
             slice.getShort(-1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getShort((slice.length() - SIZE_OF_SHORT) + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getShort(slice.length());
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getShort(slice.length() + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
     }
 
@@ -345,30 +345,30 @@ public class TestSlice
 
         try {
             slice.getInt(-1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getInt((slice.length() - SIZE_OF_INT) + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getInt(slice.length());
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getInt(slice.length() + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
     }
 
@@ -393,30 +393,30 @@ public class TestSlice
 
         try {
             slice.getLong(-1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getLong((slice.length() - SIZE_OF_LONG) + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getLong(slice.length());
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getLong(slice.length() + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
     }
 
@@ -441,30 +441,30 @@ public class TestSlice
 
         try {
             slice.getFloat(-1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getFloat((slice.length() - SIZE_OF_FLOAT) + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getFloat(slice.length());
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getFloat(slice.length() + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
     }
 
@@ -489,30 +489,30 @@ public class TestSlice
 
         try {
             slice.getDouble(-1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getDouble((slice.length() - SIZE_OF_DOUBLE) + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getDouble(slice.length());
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
 
         try {
             slice.getDouble(slice.length() + 1);
-            fail("expected IndexOutOfBoundsException");
+            fail("expected AssertionError");
         }
-        catch (IndexOutOfBoundsException e) {
+        catch (AssertionError e) {
         }
     }
 


### PR DESCRIPTION
Before:

```
Benchmark                                        Mode Thr    Cnt  Sec         Mean   Mean error    Units
n.r.b.FloatBufferBenchmarks.testBufferAccess    thrpt   1      4    1       97.465        0.234   ops/ms
n.r.b.FloatBufferBenchmarks.testDirectAccess    thrpt   1      4    1      100.365        2.625   ops/ms
n.r.b.FloatBufferBenchmarks.testHeapAccess      thrpt   1      4    1       98.636        2.494   ops/ms
n.r.b.FloatBufferBenchmarks.testSliceAccess     thrpt   1      4    1       63.436        5.909   ops/ms
```

After, with `-ea`:

```
Benchmark                                        Mode Thr    Cnt  Sec         Mean   Mean error    Units
n.r.b.FloatBufferBenchmarks.testBufferAccess    thrpt   1      4    1       97.700        1.689   ops/ms
n.r.b.FloatBufferBenchmarks.testDirectAccess    thrpt   1      4    1       94.973        7.757   ops/ms
n.r.b.FloatBufferBenchmarks.testHeapAccess      thrpt   1      4    1       98.593        5.100   ops/ms
n.r.b.FloatBufferBenchmarks.testSliceAccess     thrpt   1      4    1       71.493        0.777   ops/ms
```

After, with `-da`:

```
Benchmark                                        Mode Thr    Cnt  Sec         Mean   Mean error    Units
n.r.b.FloatBufferBenchmarks.testBufferAccess    thrpt   1      4    1      100.675        2.361   ops/ms
n.r.b.FloatBufferBenchmarks.testDirectAccess    thrpt   1      4    1       99.485        1.123   ops/ms
n.r.b.FloatBufferBenchmarks.testHeapAccess      thrpt   1      4    1      101.129        1.471   ops/ms
n.r.b.FloatBufferBenchmarks.testSliceAccess     thrpt   1      4    1       96.282        2.697   ops/ms
```

Benchmark code: https://gist.github.com/stevenschlansker/7143614
