### PR TITLE
Murmur3-128 implementation

### DIFF
--- a/src/main/java/io/airlift/slice/Murmur3.java
+++ b/src/main/java/io/airlift/slice/Murmur3.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+public class Murmur3
+{
+    private static final long C1 = 0x87c37b91114253d5L;
+    private static final long C2 = 0x4cf5ad432745937fL;
+
+    private final static long DEFAULT_SEED = 0;
+
+    public static Slice hash(Slice data)
+    {
+        return hash(data, 0, data.length());
+    }
+
+    public static Slice hash(Slice data, int offset, int length)
+    {
+        return hash(DEFAULT_SEED, data, offset, length);
+    }
+
+    public static Slice hash(long seed, Slice data, int offset, int length)
+    {
+        final int fastLimit = offset + length - 2 * SizeOf.SIZE_OF_LONG;
+
+        long h1 = seed;
+        long h2 = seed;
+
+        int current = offset;
+        while (current < fastLimit) {
+            long k1 = data.getLong(current);
+            current += SizeOf.SIZE_OF_LONG;
+
+            long k2 = data.getLong(current);
+            current += SizeOf.SIZE_OF_LONG;
+
+            k1 *= C1;
+            k1 = Long.rotateLeft(k1, 31);
+            k1 *= C2;
+            h1 ^= k1;
+
+            h1 = Long.rotateLeft(h1, 27);
+            h1 += h2;
+            h1 = h1 * 5 + 0x52dce729L;
+
+            k2 *= C2;
+            k2 = Long.rotateLeft(k2, 33);
+            k2 *= C1;
+            h2 ^= k2;
+
+            h2 = Long.rotateLeft(h2, 31);
+            h2 += h1;
+            h2 = h2 * 5 + 0x38495ab5L;
+        }
+
+        long k1 = 0;
+        long k2 = 0;
+
+        switch (length & 15) {
+            case 15:
+                k2 ^= ((long) data.getUnsignedByte(current + 14)) << 48;
+            case 14:
+                k2 ^= ((long) data.getUnsignedByte(current + 13)) << 40;
+            case 13:
+                k2 ^= ((long) data.getUnsignedByte(current + 12)) << 32;
+            case 12:
+                k2 ^= ((long) data.getUnsignedByte(current + 11)) << 24;
+            case 11:
+                k2 ^= ((long) data.getUnsignedByte(current + 10)) << 16;
+            case 10:
+                k2 ^= ((long) data.getUnsignedByte(current + 9)) << 8;
+            case 9:
+                k2 ^= ((long) data.getUnsignedByte(current + 8)) << 0;
+
+                k2 *= C2;
+                k2 = Long.rotateLeft(k2, 33);
+                k2 *= C1;
+                h2 ^= k2;
+
+            case 8:
+                k1 ^= ((long) data.getUnsignedByte(current + 7)) << 56;
+            case 7:
+                k1 ^= ((long) data.getUnsignedByte(current + 6)) << 48;
+            case 6:
+                k1 ^= ((long) data.getUnsignedByte(current + 5)) << 40;
+            case 5:
+                k1 ^= ((long) data.getUnsignedByte(current + 4)) << 32;
+            case 4:
+                k1 ^= ((long) data.getUnsignedByte(current + 3)) << 24;
+            case 3:
+                k1 ^= ((long) data.getUnsignedByte(current + 2)) << 16;
+            case 2:
+                k1 ^= ((long) data.getUnsignedByte(current + 1)) << 8;
+            case 1:
+                k1 ^= ((long) data.getUnsignedByte(current + 0)) << 0;
+
+                k1 *= C1;
+                k1 = Long.rotateLeft(k1, 31);
+                k1 *= C2;
+                h1 ^= k1;
+        }
+
+        h1 ^= length;
+        h2 ^= length;
+
+        h1 += h2;
+        h2 += h1;
+
+        h1 = mix64(h1);
+        h2 = mix64(h2);
+
+        h1 += h2;
+        h2 += h1;
+
+        Slice result = Slices.allocate(16);
+        result.setLong(0, h1);
+        result.setLong(8, h2);
+
+        return result;
+    }
+
+    /**
+     * Returns the 64 most significant bits of the Murmur128 hash of the provided value
+     */
+    public static long hash64(Slice data)
+    {
+        return hash64(data, 0, data.length());
+    }
+
+    public static long hash64(Slice data, int offset, int length)
+    {
+        return hash64(DEFAULT_SEED, data, offset, length);
+    }
+
+    public static long hash64(long seed, Slice data, int offset, int length)
+    {
+        final int fastLimit = offset + length - 2 * SizeOf.SIZE_OF_LONG;
+
+        long h1 = seed;
+        long h2 = seed;
+
+        int current = offset;
+        while (current < fastLimit) {
+            long k1 = data.getLong(current);
+            current += SizeOf.SIZE_OF_LONG;
+
+            long k2 = data.getLong(current);
+            current += SizeOf.SIZE_OF_LONG;
+
+            k1 *= C1;
+            k1 = Long.rotateLeft(k1, 31);
+            k1 *= C2;
+            h1 ^= k1;
+
+            h1 = Long.rotateLeft(h1, 27);
+            h1 += h2;
+            h1 = h1 * 5 + 0x52dce729L;
+
+            k2 *= C2;
+            k2 = Long.rotateLeft(k2, 33);
+            k2 *= C1;
+            h2 ^= k2;
+
+            h2 = Long.rotateLeft(h2, 31);
+            h2 += h1;
+            h2 = h2 * 5 + 0x38495ab5L;
+        }
+
+        long k1 = 0;
+        long k2 = 0;
+
+        switch (length & 15) {
+            case 15:
+                k2 ^= ((long) data.getUnsignedByte(current + 14)) << 48;
+            case 14:
+                k2 ^= ((long) data.getUnsignedByte(current + 13)) << 40;
+            case 13:
+                k2 ^= ((long) data.getUnsignedByte(current + 12)) << 32;
+            case 12:
+                k2 ^= ((long) data.getUnsignedByte(current + 11)) << 24;
+            case 11:
+                k2 ^= ((long) data.getUnsignedByte(current + 10)) << 16;
+            case 10:
+                k2 ^= ((long) data.getUnsignedByte(current + 9)) << 8;
+            case 9:
+                k2 ^= ((long) data.getUnsignedByte(current + 8)) << 0;
+
+                k2 *= C2;
+                k2 = Long.rotateLeft(k2, 33);
+                k2 *= C1;
+                h2 ^= k2;
+
+            case 8:
+                k1 ^= ((long) data.getUnsignedByte(current + 7)) << 56;
+            case 7:
+                k1 ^= ((long) data.getUnsignedByte(current + 6)) << 48;
+            case 6:
+                k1 ^= ((long) data.getUnsignedByte(current + 5)) << 40;
+            case 5:
+                k1 ^= ((long) data.getUnsignedByte(current + 4)) << 32;
+            case 4:
+                k1 ^= ((long) data.getUnsignedByte(current + 3)) << 24;
+            case 3:
+                k1 ^= ((long) data.getUnsignedByte(current + 2)) << 16;
+            case 2:
+                k1 ^= ((long) data.getUnsignedByte(current + 1)) << 8;
+            case 1:
+                k1 ^= ((long) data.getUnsignedByte(current + 0)) << 0;
+
+                k1 *= C1;
+                k1 = Long.rotateLeft(k1, 31);
+                k1 *= C2;
+                h1 ^= k1;
+        }
+
+        h1 ^= length;
+        h2 ^= length;
+
+        h1 += h2;
+        h2 += h1;
+
+        h1 = mix64(h1);
+        h2 = mix64(h2);
+
+        return h1 + h2;
+    }
+
+    /**
+     * Special-purpose version for hashing a single long value. Value is treated as little-endian
+     */
+    public static long hash64(long value)
+    {
+        long h2 = DEFAULT_SEED ^ SizeOf.SIZE_OF_LONG;
+        long h1 = h2 + (h2 ^ (Long.rotateLeft(value * C1, 31) * C2));
+
+        return mix64(h1) + mix64(h1 + h2);
+    }
+
+    private static long mix64(long k)
+    {
+        k ^= k >>> 33;
+        k *= 0xff51afd7ed558ccdL;
+        k ^= k >>> 33;
+        k *= 0xc4ceb9fe1a85ec53L;
+        k ^= k >>> 33;
+
+        return k;
+    }
+}

--- a/src/test/java/io/airlift/slice/BenchmarkMurmur3.java
+++ b/src/test/java/io/airlift/slice/BenchmarkMurmur3.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+import com.google.common.hash.Hashing;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(5)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkMurmur3
+{
+    @GenerateMicroBenchmark
+    public long hash64(Data data)
+    {
+        return Murmur3.hash64(data.getSlice());
+    }
+
+    @GenerateMicroBenchmark
+    public Slice hash(Data data)
+    {
+        return Murmur3.hash(data.getSlice());
+    }
+
+    @GenerateMicroBenchmark
+    public long guava(Data data)
+    {
+        return Hashing.murmur3_128().hashBytes(data.getBytes()).asLong();
+    }
+
+    @GenerateMicroBenchmark
+    public long specializedHashLong(Data data)
+    {
+        return Murmur3.hash64(data.getLong());
+    }
+
+    @GenerateMicroBenchmark
+    public long hashLong(Data data)
+    {
+        return Murmur3.hash64(data.getSlice(), 0, 8);
+    }
+
+    @State(Scope.Thread)
+    public static class Data
+    {
+        private byte[] bytes;
+        private Slice slice;
+        private long value;
+
+        @Setup
+        public void setup()
+        {
+            bytes = new byte[1024 * 1024]; // 1 MB
+            ThreadLocalRandom.current().nextBytes(bytes);
+            slice = Slices.wrappedBuffer(bytes);
+
+            value = ThreadLocalRandom.current().nextLong();
+        }
+
+        public Slice getSlice()
+        {
+            return slice;
+        }
+
+        public byte[] getBytes()
+        {
+            return bytes;
+        }
+
+        public long getLong()
+        {
+            return value;
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkMurmur3.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}
+

--- a/src/test/java/io/airlift/slice/TestMurmur3.java
+++ b/src/test/java/io/airlift/slice/TestMurmur3.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestMurmur3
+{
+    @Test(invocationCount = 100)
+    public void testLessThan16Bytes()
+            throws Exception
+    {
+        byte[] data = randomBytes(ThreadLocalRandom.current().nextInt(16));
+
+        HashCode expected = Hashing.murmur3_128().hashBytes(data);
+        Slice actual = Murmur3.hash(Slices.wrappedBuffer(data));
+
+        assertEquals(actual.getBytes(), expected.asBytes());
+    }
+
+    @Test(invocationCount = 100)
+    public void testMoreThan16Bytes()
+            throws Exception
+    {
+        byte[] data = randomBytes(131);
+
+        HashCode expected = Hashing.murmur3_128().hashBytes(data);
+        Slice actual = Murmur3.hash(Slices.wrappedBuffer(data));
+
+        assertEquals(actual.getBytes(), expected.asBytes());
+    }
+
+    @Test(invocationCount = 100)
+    public void testOffsetAndLength()
+            throws Exception
+    {
+        byte[] data = randomBytes(131);
+
+        int offset = 13;
+        int length = 55;
+
+        HashCode expected = Hashing.murmur3_128().hashBytes(data, offset, length);
+        Slice actual = Murmur3.hash(Slices.wrappedBuffer(data), offset, length);
+
+        assertEquals(actual.getBytes(), expected.asBytes());
+    }
+
+    @Test(invocationCount = 100)
+    public void testNonDefaultSeed()
+            throws Exception
+    {
+        byte[] data = randomBytes(131);
+
+        int seed = 123456789;
+
+        HashCode expected = Hashing.murmur3_128(seed).hashBytes(data);
+        Slice actual = Murmur3.hash(seed, Slices.wrappedBuffer(data), 0, data.length);
+
+        assertEquals(actual.getBytes(), expected.asBytes());
+    }
+
+    @Test(invocationCount = 100)
+    public void testLessThan16Bytes64()
+            throws Exception
+    {
+        byte[] data = randomBytes(ThreadLocalRandom.current().nextInt(16));
+
+        long expected = Murmur3.hash(Slices.wrappedBuffer(data)).getLong(0);
+        long actual = Murmur3.hash64(Slices.wrappedBuffer(data));
+
+        assertEquals(actual, expected);
+    }
+
+    @Test(invocationCount = 100)
+    public void testMoreThan16Bytes64()
+            throws Exception
+    {
+        byte[] data = randomBytes(131);
+
+        long expected = Murmur3.hash(Slices.wrappedBuffer(data)).getLong(0);
+        long actual = Murmur3.hash64(Slices.wrappedBuffer(data));
+
+        assertEquals(actual, expected);
+    }
+
+    @Test(invocationCount = 100)
+    public void testOffsetAndLength64()
+            throws Exception
+    {
+        byte[] data = randomBytes(131);
+
+        int offset = 13;
+        int length = 55;
+
+        long expected = Murmur3.hash(Slices.wrappedBuffer(data), offset, length).getLong(0);
+        long actual = Murmur3.hash64(Slices.wrappedBuffer(data), offset, length);
+
+        assertEquals(actual, expected);
+    }
+
+    @Test(invocationCount = 100)
+    public void testNonDefaultSeed64()
+            throws Exception
+    {
+        byte[] data = randomBytes(131);
+
+        int seed = 123456789;
+
+        long expected = Murmur3.hash(seed, Slices.wrappedBuffer(data), 0, data.length).getLong(0);
+        long actual = Murmur3.hash64(seed, Slices.wrappedBuffer(data), 0, data.length);
+
+        assertEquals(actual, expected);
+    }
+
+    @Test(invocationCount = 100)
+    public void test64ReturnsMsb()
+            throws Exception
+    {
+        byte[] data = randomBytes(ThreadLocalRandom.current().nextInt(200));
+
+        long expected = Murmur3.hash(Slices.wrappedBuffer(data)).getLong(0);
+        long actual = Murmur3.hash64(Slices.wrappedBuffer(data));
+
+        assertEquals(actual, expected);
+    }
+
+    @Test(invocationCount = 100)
+    public void testSingleLong()
+            throws Exception
+    {
+        long value = ThreadLocalRandom.current().nextLong();
+
+        Slice slice = Slices.allocate(8);
+        slice.setLong(0, value);
+        long expected = Murmur3.hash64(slice);
+        long actual = Murmur3.hash64(value);
+        assertEquals(actual, expected);
+    }
+
+    private static byte[] randomBytes(int length)
+    {
+        byte[] result = new byte[length];
+        ThreadLocalRandom.current().nextBytes(result);
+        return result;
+    }
+}


### PR DESCRIPTION
Includes variants for computing:
- A full 128-bit hash from a sequence of bytes
- A 64-bit hash from a sequence of bytes
- A 64-bit hash from a single long

The 64-bit hashes are produced from the 64 most significant bits of the corresponding 128-bit hash
