### PR TITLE
Add a method to create a Slice from a raw memory address

### DIFF
--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -139,14 +139,6 @@ public final class Slices
         return new Slice(array, offset, length);
     }
 
-    public static Slice wrappedBuffer(long address, int length, Object reference)
-    {
-        if(length == 0) {
-            return EMPTY_SLICE;
-        }
-        return new Slice(null, address, length, reference);
-    }
-
     public static Slice wrappedBooleanArray(boolean... array)
     {
         return wrappedBooleanArray(array, 0, array.length);

--- a/src/main/java/io/airlift/slice/UnsafeSliceFactory.java
+++ b/src/main/java/io/airlift/slice/UnsafeSliceFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+import javax.annotation.Nullable;
+
+/**
+ * A slice factory for creating unsafe slices
+ */
+public class UnsafeSliceFactory {
+    /**
+     * Accessible only to the privileged code
+     */
+    static UnsafeSliceFactory instance = new UnsafeSliceFactory();
+
+    /**
+     * Get an instance of this factory
+     * @return an instnace of this factory
+     */
+    public static UnsafeSliceFactory getInstance() { return instance; }
+
+    /**
+     * Hidden constructor
+     */
+    UnsafeSliceFactory() {}
+
+    /**
+     * Creates a slice for directly accessing the base object.
+     */
+    public Slice newSlice(@Nullable Object base, long address, int size, @Nullable Object reference)
+    {
+        if(size == 0) {
+            return Slices.EMPTY_SLICE;
+        }
+        return new Slice(base, address, size, reference);
+    }
+}


### PR DESCRIPTION
Hi,

I am Taro L. Saito from Treasure Data, Inc.

Could you add a factory method to Slices class so that we can create a Slice from a raw memory address?  

This is necessary to reduce the overhead of creating slices through `wrappedBuffer(ByteBuffer)`. For example, to create a slice that represents a range of an off-heap memory, we first need to create a ByteBuffer representation of this memory region (by creating a DirectByteBuffer using reflection), then call `Slices.wrappedBuffer(ByteBuffer)` and `Slice#slice(index, length)` to specify the memory region. 

If we have `Slices.wrappedBuffer(address, length, reference)`, this process becomes more efficient. 
