### PR TITLE
Add utility methods for UTF-8 encoded Slices

### DIFF
--- a/src/main/java/io/airlift/slice/InvalidCodePointException.java
+++ b/src/main/java/io/airlift/slice/InvalidCodePointException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+import static java.lang.Integer.toHexString;
+
+public class InvalidCodePointException
+        extends IllegalArgumentException
+{
+    private final int codePoint;
+
+    public InvalidCodePointException(int codePoint)
+    {
+        super("Invalid code point 0x" + toHexString(codePoint).toUpperCase());
+        this.codePoint = codePoint;
+    }
+
+    public int getCodePoint()
+    {
+        return codePoint;
+    }
+}

--- a/src/main/java/io/airlift/slice/InvalidUtf8Exception.java
+++ b/src/main/java/io/airlift/slice/InvalidUtf8Exception.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+public class InvalidUtf8Exception
+        extends IllegalArgumentException
+{
+    public InvalidUtf8Exception(String message)
+    {
+        super(message);
+    }
+}

--- a/src/main/java/io/airlift/slice/SliceUtf8.java
+++ b/src/main/java/io/airlift/slice/SliceUtf8.java
@@ -1,0 +1,632 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+import static io.airlift.slice.Preconditions.checkArgument;
+import static io.airlift.slice.Preconditions.checkPositionIndex;
+import static io.airlift.slice.Preconditions.checkPositionIndexes;
+import static java.lang.Character.MAX_CODE_POINT;
+import static java.lang.Character.MAX_SURROGATE;
+import static java.lang.Character.MIN_SURROGATE;
+import static java.lang.Integer.toHexString;
+
+/**
+ * Utility methods for UTF-8 encoded slices.
+ */
+public final class SliceUtf8
+{
+    private SliceUtf8() {}
+
+    private static final int REPLACEMENT_CODE_POINT = 0xFFFD;
+
+    private static final int TOP_MASK32 = 0x8080_8080;
+    private static final long TOP_MASK64 = 0x8080_8080_8080_8080L;
+
+    private static final int[] LOWER_CODE_POINTS;
+    private static final int[] UPPER_CODE_POINTS;
+    private static final boolean[] WHITESPACE_CODE_POINTS;
+
+    static {
+        LOWER_CODE_POINTS = new int[MAX_CODE_POINT];
+        UPPER_CODE_POINTS = new int[MAX_CODE_POINT];
+        WHITESPACE_CODE_POINTS = new boolean[MAX_CODE_POINT];
+        for (int codePoint = 0; codePoint < MAX_CODE_POINT; codePoint++) {
+            int type = Character.getType(codePoint);
+            if (type != Character.SURROGATE) {
+                LOWER_CODE_POINTS[codePoint] = Character.toLowerCase(codePoint);
+                UPPER_CODE_POINTS[codePoint] = Character.toUpperCase(codePoint);
+                WHITESPACE_CODE_POINTS[codePoint] = Character.isWhitespace(codePoint);
+            }
+            else {
+                LOWER_CODE_POINTS[codePoint] = REPLACEMENT_CODE_POINT;
+                UPPER_CODE_POINTS[codePoint] = REPLACEMENT_CODE_POINT;
+                WHITESPACE_CODE_POINTS[codePoint] = false;
+            }
+        }
+    }
+
+    /**
+     * Counts the code points within UTF-8 encoded slice.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static int countCodePoints(Slice utf8)
+    {
+        return countCodePoints(utf8, 0, utf8.length());
+    }
+
+    /**
+     * Counts the code points within UTF-8 encoded slice up to {@code length}.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static int countCodePoints(Slice utf8, int offset, int length)
+    {
+        checkPositionIndexes(offset, offset + length, utf8.length());
+
+        // Quick exit if empty string
+        if (length == 0) {
+            return 0;
+        }
+
+        int continuationBytesCount = 0;
+        // Length rounded to 8 bytes
+        int length8 = length & 0x7FFF_FFF8;
+        for (; offset < length8; offset += 8) {
+            // Count bytes which are NOT the start of a code point
+            continuationBytesCount += countContinuationBytes(utf8.getLongUnchecked(offset));
+        }
+        // Enough bytes left for 32 bits?
+        if (offset + 4 < length) {
+            // Count bytes which are NOT the start of a code point
+            continuationBytesCount += countContinuationBytes(utf8.getIntUnchecked(offset));
+
+            offset += 4;
+        }
+        // Do the rest one by one
+        for (; offset < length; offset++) {
+            // Count bytes which are NOT the start of a code point
+            continuationBytesCount += countContinuationBytes(utf8.getByteUnchecked(offset));
+        }
+
+        assert continuationBytesCount <= length;
+        return length - continuationBytesCount;
+    }
+
+    /**
+     * Gets the substring starting at {@code codePointStart} and extending for
+     * {@code codePointLength} code points.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static Slice substring(Slice utf8, int codePointStart, int codePointLength)
+    {
+        checkArgument(codePointStart >= 0, "codePointStart is negative");
+        checkArgument(codePointLength >= 0, "codePointLength is negative");
+
+        int indexStart = offsetOfCodePoint(utf8, codePointStart);
+        if (indexStart < 0) {
+            throw new IllegalArgumentException("UTF-8 does not contain " + codePointStart + " code points");
+        }
+        if (codePointLength == 0) {
+            return Slices.EMPTY_SLICE;
+        }
+        int indexEnd = offsetOfCodePoint(utf8, indexStart, codePointLength - 1);
+        if (indexEnd < 0) {
+            throw new IllegalArgumentException("UTF-8 does not contain " + (codePointStart + codePointLength) + " code points");
+        }
+        indexEnd += lengthOfCodePoint(utf8, indexEnd);
+        if (indexEnd > utf8.length()) {
+            throw new InvalidUtf8Exception("UTF-8 is not well formed");
+        }
+        return utf8.slice(indexStart, indexEnd - indexStart);
+    }
+
+    /**
+     * Reverses the slice code point by code point.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static Slice reverse(Slice utf8)
+    {
+        int length = utf8.length();
+        Slice reverse = Slices.allocate(length);
+
+        int forwardPosition = 0;
+        int reversePosition = length;
+        while (forwardPosition < length) {
+            int codePointLength = lengthOfCodePointFromStartByte(utf8.getByteUnchecked(forwardPosition));
+
+            // backup the reverse pointer
+            reversePosition -= codePointLength;
+            if (reversePosition < 0) {
+                throw new InvalidUtf8Exception("UTF-8 is not well formed");
+            }
+            // copy the character
+            switch (codePointLength) {
+                case 1:
+                    reverse.setByteUnchecked(reversePosition, utf8.getByteUnchecked(forwardPosition));
+                    break;
+                case 2:
+                    reverse.setShortUnchecked(reversePosition, utf8.getShortUnchecked(forwardPosition));
+                    break;
+                case 3:
+                    reverse.setByteUnchecked(reversePosition, utf8.getByteUnchecked(forwardPosition));
+                    reverse.setShortUnchecked(reversePosition + 1, utf8.getShortUnchecked(forwardPosition + 1));
+                    break;
+                case 4:
+                    reverse.setIntUnchecked(reversePosition, utf8.getIntUnchecked(forwardPosition));
+                    break;
+                default:
+                    throw new IllegalStateException("Invalid code point length " + codePointLength);
+            }
+
+            forwardPosition += codePointLength;
+        }
+        return reverse;
+    }
+
+    /**
+     * Converts slice to upper case code point by code point.  This method does
+     * not perform perform locale-sensitive, context-sensitive, or one-to-many
+     * mappings required for some languages.  Specifically, this will return
+     * incorrect results for Lithuanian, Turkish, and Azeri.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static Slice toUpperCase(Slice utf8)
+    {
+        int length = utf8.length();
+        Slice upperUtf8 = Slices.allocate(length);
+
+        int position = 0;
+        int upperPosition = 0;
+        while (position < length) {
+            int codePoint = getCodePointAt(utf8, position);
+            int upperCodePoint = UPPER_CODE_POINTS[codePoint];
+
+            // grow slice if necessary
+            int nextUpperPosition = upperPosition + lengthOfCodePoint(upperCodePoint);
+            if (nextUpperPosition > length) {
+                upperUtf8 = Slices.ensureSize(upperUtf8, nextUpperPosition);
+            }
+
+            // write new byte
+            setCodePointAt(upperCodePoint, upperUtf8, upperPosition);
+
+            position += lengthOfCodePoint(codePoint);
+            upperPosition = nextUpperPosition;
+        }
+        return upperUtf8.slice(0, upperPosition);
+    }
+
+    /**
+     * Converts slice to lower case code point by code point.  This method does
+     * not perform perform locale-sensitive, context-sensitive, or one-to-many
+     * mappings required for some languages.  Specifically, this will return
+     * incorrect results for Lithuanian, Turkish, and Azeri.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static Slice toLowerCase(Slice utf8)
+    {
+        int length = utf8.length();
+        Slice lowerUtf8 = Slices.allocate(length);
+
+        int position = 0;
+        int lowerPosition = 0;
+        while (position < length) {
+            int codePoint = getCodePointAt(utf8, position);
+            int lowerCodePoint = LOWER_CODE_POINTS[codePoint];
+
+            // grow slice if necessary
+            int nextLowerPosition = lowerPosition + lengthOfCodePoint(lowerCodePoint);
+            if (nextLowerPosition > length) {
+                lowerUtf8 = Slices.ensureSize(lowerUtf8, nextLowerPosition);
+            }
+
+            // write new byte
+            setCodePointAt(lowerCodePoint, lowerUtf8, lowerPosition);
+
+            position += lengthOfCodePoint(codePoint);
+            lowerPosition = nextLowerPosition;
+        }
+        return lowerUtf8.slice(0, lowerPosition);
+    }
+
+    /**
+     * Removes all white space characters from the left string of the string.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static Slice leftTrim(Slice utf8)
+    {
+        int length = utf8.length();
+
+        int position = firstNonWhitespacePosition(utf8);
+        return utf8.slice(position, length - position);
+    }
+
+    private static int firstNonWhitespacePosition(Slice utf8)
+    {
+        int length = utf8.length();
+
+        int position = 0;
+        while (position < length) {
+            int codePoint = getCodePointAt(utf8, position);
+            if (!WHITESPACE_CODE_POINTS[codePoint]) {
+                break;
+            }
+            position += lengthOfCodePoint(codePoint);
+        }
+        return position;
+    }
+
+    /**
+     * Removes all white space characters from the right side of the string.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static Slice rightTrim(Slice utf8)
+    {
+        int position = lastNonWhitespacePosition(utf8, 0);
+        return utf8.slice(0, position);
+    }
+
+    private static int lastNonWhitespacePosition(Slice utf8, int minPosition)
+    {
+        int length = utf8.length();
+
+        int position = length;
+        while (minPosition < position) {
+            int codePoint = getCodePointBefore(utf8, position);
+            if (!WHITESPACE_CODE_POINTS[codePoint]) {
+                break;
+            }
+            position -= lengthOfCodePoint(codePoint);
+        }
+        return position;
+    }
+
+    /**
+     * Removes all white space characters from the left and right side of the string.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static Slice trim(Slice utf8)
+    {
+        int start = firstNonWhitespacePosition(utf8);
+        int end = lastNonWhitespacePosition(utf8, start);
+        return utf8.slice(start, end - start);
+    }
+
+    /**
+     * Finds the index of the first byte of the code point at a position, or
+     * {@code -1} if the position is not withing the slice.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static int offsetOfCodePoint(Slice utf8, int codePointCount)
+    {
+        return offsetOfCodePoint(utf8, 0, codePointCount);
+    }
+
+    /**
+     * Starting from {@code position} bytes in {@code utf8}, finds the
+     * index of the first byte of the code point {@code codePointCount}
+     * in the slice.  If the slice does not contain
+     * {@code codePointCount} code points after {@code position}, {@code -1}
+     * is returned.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static int offsetOfCodePoint(Slice utf8, int position, int codePointCount)
+    {
+        checkPositionIndex(position, utf8.length());
+        checkArgument(codePointCount >= 0, "codePointPosition is negative");
+
+        // Quick exit if we are sure that the position is after the end
+        if (utf8.length() - position <= codePointCount) {
+            return -1;
+        }
+        if (codePointCount == 0) {
+            return position;
+        }
+
+        int correctIndex = codePointCount + position;
+        // Length rounded to 8 bytes
+        int length8 = utf8.length() & 0x7FFF_FFF8;
+        // While we have enough bytes left and we need at least 8 characters process 8 bytes at once
+        while (position < length8 && correctIndex >= position + 8) {
+            // Count bytes which are NOT the start of a code point
+            correctIndex += countContinuationBytes(utf8.getLongUnchecked(position));
+
+            position += 8;
+        }
+        // Length rounded to 4 bytes
+        int length4 = utf8.length() & 0x7FFF_FFFC;
+        // While we have enough bytes left and we need at least 4 characters process 4 bytes at once
+        while (position < length4 && correctIndex >= position + 4) {
+            // Count bytes which are NOT the start of a code point
+            correctIndex += countContinuationBytes(utf8.getIntUnchecked(position));
+
+            position += 4;
+        }
+        // Do the rest one by one, always check the last byte to find the end of the code point
+        while (position < utf8.length()) {
+            // Count bytes which are NOT the start of a code point
+            correctIndex += countContinuationBytes(utf8.getByteUnchecked(position));
+            if (position == correctIndex) {
+                break;
+            }
+
+            position++;
+        }
+
+        if (position == correctIndex && correctIndex < utf8.length()) {
+            return correctIndex;
+        }
+        return -1;
+    }
+
+    /**
+     * Gets the UTF-8 sequence length of the code point at {@code position}.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static int lengthOfCodePoint(Slice utf8, int position)
+    {
+        return lengthOfCodePointFromStartByte(utf8.getByte(position));
+    }
+
+    /**
+     * Gets the UTF-8 sequence length of the code point.
+     *
+     * @throws InvalidCodePointException if code point is not within a valid range
+     */
+    public static int lengthOfCodePoint(int codePoint)
+    {
+        if (codePoint < 0) {
+            throw new InvalidCodePointException(codePoint);
+        }
+        if (codePoint < 0x80) {
+            // normal ASCII
+            // 0xxx_xxxx
+            return 1;
+        }
+        if (codePoint < 0x800) {
+            return 2;
+        }
+        if (codePoint < 0x1_0000) {
+            return 3;
+        }
+        if (codePoint < 0x11_0000) {
+            return 4;
+        }
+        // Per RFC3629, UTF-8 is limited to 4 bytes, so more bytes are illegal
+        throw new InvalidCodePointException(codePoint);
+    }
+
+    /**
+     * Gets the UTF-8 sequence length using the sequence start byte.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static int lengthOfCodePointFromStartByte(byte startByte)
+    {
+        int unsignedStartByte = startByte & 0xFF;
+        if (unsignedStartByte < 0x80) {
+            // normal ASCII
+            // 0xxx_xxxx
+            return 1;
+        }
+        if (unsignedStartByte < 0xc0) {
+            // illegal bytes
+            // 10xx_xxxx
+            throw new InvalidUtf8Exception("Illegal start 0x" + toHexString(unsignedStartByte).toUpperCase() + " of code point");
+        }
+        if (unsignedStartByte < 0xe0) {
+            // 110x_xxxx 10xx_xxxx
+            return 2;
+        }
+        if (unsignedStartByte < 0xf0) {
+            // 1110_xxxx 10xx_xxxx 10xx_xxxx
+            return 3;
+        }
+        if (unsignedStartByte < 0xf8) {
+            // 1111_0xxx 10xx_xxxx 10xx_xxxx 10xx_xxxx
+            return 4;
+        }
+        // Per RFC3629, UTF-8 is limited to 4 bytes, so more bytes are illegal
+        throw new InvalidUtf8Exception("Illegal start 0x" + toHexString(unsignedStartByte).toUpperCase() + " of code point");
+    }
+
+    /**
+     * Gets the UTF-8 encoded code point at the {@code position}.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static int getCodePointAt(Slice utf8, int position)
+    {
+        int unsignedStartByte = utf8.getByte(position) & 0xFF;
+        if (unsignedStartByte < 0x80) {
+            // normal ASCII
+            // 0xxx_xxxx
+            return unsignedStartByte;
+        }
+        if (unsignedStartByte < 0xc0) {
+            // illegal bytes
+            // 10xx_xxxx
+            throw new InvalidUtf8Exception("Illegal start 0x" + toHexString(unsignedStartByte).toUpperCase() + " of code point");
+        }
+        if (unsignedStartByte < 0xe0) {
+            // 110x_xxxx 10xx_xxxx
+            if (position + 1 >= utf8.length()) {
+                throw new InvalidUtf8Exception("UTF-8 sequence truncated");
+            }
+            return ((unsignedStartByte & 0b0001_1111) << 6) |
+                    (utf8.getByte(position + 1) & 0b0011_1111);
+        }
+        if (unsignedStartByte < 0xf0) {
+            // 1110_xxxx 10xx_xxxx 10xx_xxxx
+            if (position + 2 >= utf8.length()) {
+                throw new InvalidUtf8Exception("UTF-8 sequence truncated");
+            }
+            return ((unsignedStartByte & 0b0000_1111) << 12) |
+                    ((utf8.getByteUnchecked(position + 1) & 0b0011_1111) << 6) |
+                    (utf8.getByteUnchecked(position + 2) & 0b0011_1111);
+        }
+        if (unsignedStartByte < 0xf8) {
+            // 1111_0xxx 10xx_xxxx 10xx_xxxx 10xx_xxxx
+            if (position + 3 >= utf8.length()) {
+                throw new InvalidUtf8Exception("UTF-8 sequence truncated");
+            }
+            return ((unsignedStartByte & 0b0000_0111) << 18) |
+                    ((utf8.getByteUnchecked(position + 1) & 0b0011_1111) << 12) |
+                    ((utf8.getByteUnchecked(position + 2) & 0b0011_1111) << 6) |
+                    (utf8.getByteUnchecked(position + 3) & 0b0011_1111);
+        }
+        // Per RFC3629, UTF-8 is limited to 4 bytes, so more bytes are illegal
+        throw new InvalidUtf8Exception("Illegal start 0x" + toHexString(unsignedStartByte).toUpperCase() + " of code point");
+    }
+
+    /**
+     * Gets the UTF-8 encoded code point before the {@code position}.
+     * </p>
+     * Note: This method does not explicitly check for valid UTF-8, and may
+     * return incorrect results or throw an exception for invalid UTF-8.
+     */
+    public static int getCodePointBefore(Slice utf8, int position)
+    {
+        byte unsignedByte = utf8.getByte(position - 1);
+        if (!isContinuationByte(unsignedByte)) {
+            return unsignedByte & 0xFF;
+        }
+        if (!isContinuationByte(utf8.getByte(position - 2))) {
+            return getCodePointAt(utf8, position - 2);
+        }
+        if (!isContinuationByte(utf8.getByte(position - 3))) {
+            return getCodePointAt(utf8, position - 3);
+        }
+        if (!isContinuationByte(utf8.getByte(position - 4))) {
+            return getCodePointAt(utf8, position - 4);
+        }
+
+        // Per RFC3629, UTF-8 is limited to 4 bytes, so more bytes are illegal
+        throw new InvalidUtf8Exception("UTF-8 is not well formed");
+    }
+
+    private static boolean isContinuationByte(byte b)
+    {
+        return (b & 0b1100_0000) == 0b1000_0000;
+    }
+
+    /**
+     * Convert the code point to UTF-8.
+     * </p>
+     *
+     * @throws InvalidCodePointException if code point is not within a valid range
+     */
+    public static Slice codePointToUtf8(int codePoint)
+    {
+        Slice utf8 = Slices.allocate(lengthOfCodePoint(codePoint));
+        setCodePointAt(codePoint, utf8, 0);
+        return utf8;
+    }
+
+    /**
+     * Sets the UTF-8 sequence for code point at the {@code position}.
+     *
+     * @throws InvalidCodePointException if code point is not within a valid range
+     */
+    public static int setCodePointAt(int codePoint, Slice utf8, int position)
+    {
+        if (codePoint < 0) {
+            throw new InvalidCodePointException(codePoint);
+        }
+        if (codePoint < 0x80) {
+            // normal ASCII
+            // 0xxx_xxxx
+            utf8.setByte(position, codePoint);
+            return 1;
+        }
+        if (codePoint < 0x800) {
+            // 110x_xxxx 10xx_xxxx
+            utf8.setByte(position, 0b1100_0000 | (codePoint >>> 6));
+            utf8.setByte(position + 1, 0b1000_0000 | (codePoint & 0b0011_1111));
+            return 2;
+        }
+        if (MIN_SURROGATE <= codePoint && codePoint <= MAX_SURROGATE) {
+            throw new InvalidCodePointException(codePoint);
+        }
+        if (codePoint < 0x1_0000) {
+            // 1110_xxxx 10xx_xxxx 10xx_xxxx
+            utf8.setByte(position, 0b1110_0000 | ((codePoint >>> 12) & 0b0000_1111));
+            utf8.setByte(position + 1, 0b1000_0000 | ((codePoint >>> 6) & 0b0011_1111));
+            utf8.setByte(position + 2, 0b1000_0000 | (codePoint & 0b0011_1111));
+            return 3;
+        }
+        if (codePoint < 0x11_0000) {
+            // 1111_0xxx 10xx_xxxx 10xx_xxxx 10xx_xxxx
+            utf8.setByte(position, 0b1111_0000 | ((codePoint >>> 18) & 0b0000_0111));
+            utf8.setByte(position + 1, 0b1000_0000 | ((codePoint >>> 12) & 0b0011_1111));
+            utf8.setByte(position + 2, 0b1000_0000 | ((codePoint >>> 6) & 0b0011_1111));
+            utf8.setByte(position + 3, 0b1000_0000 | (codePoint & 0b0011_1111));
+            return 4;
+        }
+        // Per RFC3629, UTF-8 is limited to 4 bytes, so more bytes are illegal
+        throw new InvalidCodePointException(codePoint);
+    }
+
+    private static int countContinuationBytes(byte i8)
+    {
+        // see below
+        int value = i8 & 0xff;
+        return (value >>> 7) & (~value >>> 6);
+    }
+
+    private static int countContinuationBytes(int i32)
+    {
+        // see below
+        i32 = ((i32 & TOP_MASK32) >>> 1) & (~i32);
+        return Integer.bitCount(i32);
+    }
+
+    private static int countContinuationBytes(long i64)
+    {
+        // Count the number of bytes that match 0b10xx_xxxx as follows:
+        // 1. Mask off the 8th bit of every byte and shift it into the 7th position.
+        // 2. Then invert the bytes, which turns the 0 in the 7th bit to a one.
+        // 3. And together the restults of step 1 and 2, giving us a one in the 7th
+        //    position if the byte matched.
+        // 4. Count the number of bits in the result, which is the number of bytes
+        //    that matched.
+        i64 = ((i64 & TOP_MASK64) >>> 1) & (~i64);
+        return Long.bitCount(i64);
+    }
+}

--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -59,7 +59,7 @@ public final class Slices
         else {
             newCapacity = existingSlice.length();
         }
-        int minNewCapacity = existingSlice.length() + minWritableBytes;
+        int minNewCapacity = minWritableBytes;
         while (newCapacity < minNewCapacity) {
             if (newCapacity < SLICE_ALLOC_THRESHOLD) {
                 newCapacity <<= 1;
@@ -69,7 +69,7 @@ public final class Slices
             }
         }
 
-        Slice newSlice = Slices.allocate(newCapacity);
+        Slice newSlice = allocate(newCapacity);
         newSlice.setBytes(0, existingSlice, 0, existingSlice.length());
         return newSlice;
     }
@@ -123,7 +123,7 @@ public final class Slices
         throw new IllegalArgumentException("cannot wrap " + buffer.getClass().getName());
     }
 
-    public static Slice wrappedBuffer(byte[] array)
+    public static Slice wrappedBuffer(byte... array)
     {
         if (array.length == 0) {
             return EMPTY_SLICE;

--- a/src/test/java/io/airlift/slice/SliceUtf8Benchmark.java
+++ b/src/test/java/io/airlift/slice/SliceUtf8Benchmark.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+
+import static io.airlift.slice.SliceUtf8.countCodePoints;
+import static io.airlift.slice.SliceUtf8.leftTrim;
+import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
+import static io.airlift.slice.SliceUtf8.lengthOfCodePointFromStartByte;
+import static io.airlift.slice.SliceUtf8.offsetOfCodePoint;
+import static io.airlift.slice.SliceUtf8.reverse;
+import static io.airlift.slice.SliceUtf8.rightTrim;
+import static io.airlift.slice.SliceUtf8.substring;
+import static io.airlift.slice.SliceUtf8.toLowerCase;
+import static io.airlift.slice.SliceUtf8.toUpperCase;
+import static io.airlift.slice.SliceUtf8.trim;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Character.MAX_CODE_POINT;
+import static java.lang.Character.SURROGATE;
+import static java.lang.Character.getType;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Thread)
+@OutputTimeUnit(NANOSECONDS)
+@BenchmarkMode(AverageTime)
+@Fork(1)
+@Warmup(iterations = 4, time = 500, timeUnit = MILLISECONDS)
+@Measurement(iterations = 5, time = 500, timeUnit = MILLISECONDS)
+public class SliceUtf8Benchmark
+{
+    @Benchmark
+    public int benchmarkLengthOfCodePointFromStartByte(BenchmarkData data)
+    {
+        Slice slice = data.getSlice();
+        int i = 0;
+        int codePoints = 0;
+        while (i < slice.length()) {
+            i += lengthOfCodePointFromStartByte(slice.getByte(i));
+            codePoints++;
+        }
+        if (codePoints != data.getLength()) {
+            throw new AssertionError();
+        }
+        return codePoints;
+    }
+
+    @Benchmark
+    public int benchmarkCountCodePoints(BenchmarkData data)
+    {
+        int codePoints = countCodePoints(data.getSlice());
+        if (codePoints != data.getLength()) {
+            throw new AssertionError();
+        }
+        return codePoints;
+    }
+
+    @Benchmark
+    public int benchmarkOffsetByCodePoints(BenchmarkData data)
+    {
+        Slice slice = data.getSlice();
+        int offset = offsetOfCodePoint(slice, data.getLength() - 1);
+        if (offset + lengthOfCodePoint(slice, offset) != slice.length()) {
+            throw new AssertionError();
+        }
+        return offset;
+    }
+
+    @Benchmark
+    public Slice benchmarkSubstring(BenchmarkData data)
+    {
+        Slice slice = data.getSlice();
+        int length = data.getLength();
+        return substring(slice, (length / 2) - 1, length / 2);
+    }
+
+    @Benchmark
+    public Slice benchmarkReverse(BenchmarkData data)
+    {
+        return reverse(data.getSlice());
+    }
+
+    @Benchmark
+    public Slice benchmarkToLowerCase(BenchmarkData data)
+    {
+        return toLowerCase(data.getSlice());
+    }
+
+    @Benchmark
+    public Slice benchmarkToUpperCase(BenchmarkData data)
+    {
+        return toUpperCase(data.getSlice());
+    }
+
+    @Benchmark
+    public Slice benchmarkLeftTrim(WhitespaceData data)
+    {
+        return leftTrim(data.getLeftWhitespace());
+    }
+
+    @Benchmark
+    public Slice benchmarkRightTrim(WhitespaceData data)
+    {
+        return rightTrim(data.getRightWhitespace());
+    }
+
+    @Benchmark
+    public Slice benchmarkTrim(WhitespaceData data)
+    {
+        return trim(data.getBothWhitespace());
+    }
+
+
+    @State(Thread)
+    public static class BenchmarkData
+    {
+        private static final int[] ASCII_CODE_POINTS;
+        private static final int[] ALL_CODE_POINTS;
+
+        static {
+            ASCII_CODE_POINTS = IntStream.range(0, 0x7F)
+                    .toArray();
+            ALL_CODE_POINTS = IntStream.range(0, MAX_CODE_POINT)
+                    .filter(codePoint -> getType(codePoint) != SURROGATE)
+                    .toArray();
+        }
+
+        @Param({ "2", "5", "10", "100", "1000", "10000" })
+        private int length;
+
+        @Param({ "true", "false" })
+        private boolean ascii;
+
+        private Slice slice;
+        private int[] codePoints;
+
+        @Setup
+        public void setup()
+        {
+            int[] codePointSet = ascii ? ASCII_CODE_POINTS : ALL_CODE_POINTS;
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+
+            codePoints = new int[length];
+            DynamicSliceOutput sliceOutput = new DynamicSliceOutput(length * 4);
+            for (int i = 0; i < codePoints.length; i++) {
+                int codePoint = codePointSet[random.nextInt(codePointSet.length)];
+                codePoints[i] = codePoint;
+                sliceOutput.appendBytes(new String(Character.toChars(codePoint)).getBytes(StandardCharsets.UTF_8));
+            }
+            slice = sliceOutput.slice();
+        }
+
+        public Slice getSlice()
+        {
+            return slice;
+        }
+
+        public int getLength()
+        {
+            return length;
+        }
+    }
+
+    @State(Thread)
+    public static class WhitespaceData
+    {
+        private static final int[] ASCII_WHITESPACE;
+        private static final int[] ALL_WHITESPACE;
+
+        static {
+            ASCII_WHITESPACE = IntStream.range(0, 0x7F)
+                    .filter(Character::isWhitespace)
+                    .toArray();
+            ALL_WHITESPACE = IntStream.range(0, MAX_CODE_POINT)
+                    .filter(Character::isWhitespace)
+                    .toArray();
+        }
+
+        @Param({ "2", "5", "10", "100", "1000", "10000" })
+        private int length;
+
+        @Param({ "true", "false" })
+        private boolean ascii;
+
+        private Slice leftWhitespace;
+        private Slice rightWhitespace;
+        private Slice bothWhitespace;
+
+        @Setup
+        public void setup()
+        {
+            Slice whitespace = createRandomUtf8Slice(ascii ? ASCII_WHITESPACE : ALL_WHITESPACE, length + 1);
+            leftWhitespace = Slices.copyOf(whitespace);
+            leftWhitespace.setByte(leftWhitespace.length() - 1, 'X');
+            rightWhitespace = Slices.copyOf(whitespace);
+            rightWhitespace.setByte(0, 'X');
+            bothWhitespace = Slices.copyOf(whitespace);
+            bothWhitespace.setByte(length / 2, 'X');
+        }
+
+        private static Slice createRandomUtf8Slice(int[] codePointSet, int length)
+        {
+            int[] codePoints = new int[length];
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            for (int i = 0; i < codePoints.length; i++) {
+                int codePoint = codePointSet[random.nextInt(codePointSet.length)];
+                codePoints[i] = codePoint;
+            }
+            return utf8Slice(new String(codePoints, 0, codePoints.length));
+        }
+
+        public int getLength()
+        {
+            return length;
+        }
+
+        public Slice getLeftWhitespace()
+        {
+            return leftWhitespace;
+        }
+
+        public Slice getRightWhitespace()
+        {
+            return rightWhitespace;
+        }
+
+        public Slice getBothWhitespace()
+        {
+            return bothWhitespace;
+        }
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + SliceUtf8Benchmark.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/src/test/java/io/airlift/slice/TestSlice.java
+++ b/src/test/java/io/airlift/slice/TestSlice.java
@@ -13,7 +13,6 @@
  */
 package io.airlift.slice;
 
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -200,9 +199,9 @@ public class TestSlice
         String s = "apple \u2603 snowman";
         Slice slice = Slices.copiedBuffer(s, UTF_8);
 
-        assertEquals(Slices.utf8Slice(s), slice);
+        assertEquals(utf8Slice(s), slice);
         assertEquals(slice.toStringUtf8(), s);
-        assertEquals(Slices.utf8Slice(s).toStringUtf8(), s);
+        assertEquals(utf8Slice(s).toStringUtf8(), s);
     }
 
     @SuppressWarnings("CharUsedInArithmeticContext")
@@ -682,23 +681,23 @@ public class TestSlice
     {
         // slightly stronger guarantees for empty slice
         assertSame(Slices.copyOf(EMPTY_SLICE), EMPTY_SLICE);
-        assertSame(Slices.copyOf(Slices.utf8Slice("hello world"), 1, 0), EMPTY_SLICE);
+        assertSame(Slices.copyOf(utf8Slice("hello world"), 1, 0), EMPTY_SLICE);
 
-        Slice slice = Slices.utf8Slice("hello world");
+        Slice slice = utf8Slice("hello world");
         assertEquals(Slices.copyOf(slice), slice);
         assertEquals(Slices.copyOf(slice, 1, 3), slice.slice(1, 3));
 
         // verify it's an actual copy
-        Slice original = Slices.utf8Slice("hello world");
+        Slice original = utf8Slice("hello world");
         Slice copy = Slices.copyOf(original);
 
         original.fill((byte) 0);
-        assertEquals(copy, Slices.utf8Slice("hello world"));
+        assertEquals(copy, utf8Slice("hello world"));
 
         // read before beginning
         try {
             Slices.copyOf(slice, -1, slice.length());
-            Assert.fail();
+            fail();
         }
         catch (IndexOutOfBoundsException ignored) {
         }
@@ -706,7 +705,7 @@ public class TestSlice
         // read after end
         try {
             Slices.copyOf(slice, slice.length() + 1, 1);
-            Assert.fail();
+            fail();
         }
         catch (IndexOutOfBoundsException ignored) {
         }
@@ -714,7 +713,7 @@ public class TestSlice
         // start before but extend past end
         try {
             Slices.copyOf(slice, 1, slice.length());
-            Assert.fail();
+            fail();
         }
         catch (IndexOutOfBoundsException ignored) {
         }

--- a/src/test/java/io/airlift/slice/TestSlice.java
+++ b/src/test/java/io/airlift/slice/TestSlice.java
@@ -717,8 +717,60 @@ public class TestSlice
         }
         catch (IndexOutOfBoundsException ignored) {
         }
+    }
 
+    @Test
+    public void testIndexOf()
+            throws Exception
+    {
+        assertIndexOf(utf8Slice("no-match-bigger"), utf8Slice("test"));
+        assertIndexOf(utf8Slice("no"), utf8Slice("test"));
 
+        assertIndexOf(utf8Slice("test"), utf8Slice("test"));
+        assertIndexOf(utf8Slice("test-start"), utf8Slice("test"));
+        assertIndexOf(utf8Slice("end-test"), utf8Slice("test"));
+        assertIndexOf(utf8Slice("a-test-middle"), utf8Slice("test"));
+        assertIndexOf(utf8Slice("this-test-is-a-test"), utf8Slice("test"));
+
+        assertIndexOf(utf8Slice("test"), EMPTY_SLICE, 0, 0);
+        assertIndexOf(EMPTY_SLICE, utf8Slice("test"), 0, -1);
+
+        assertIndexOf(utf8Slice("test"), utf8Slice("no"), 4, -1);
+        assertIndexOf(utf8Slice("test"), utf8Slice("no"), 5, -1);
+        assertIndexOf(utf8Slice("test"), utf8Slice("no"), -1, -1);
+    }
+
+    public static void assertIndexOf(Slice data, Slice pattern, int offset, int expected)
+    {
+        assertEquals(data.indexOf(pattern, offset), expected);
+        assertEquals(data.indexOfBruteForce(pattern, offset), expected);
+    }
+
+    public static void assertIndexOf(Slice data, Slice pattern)
+    {
+        int index;
+
+        List<Integer> bruteForce = new ArrayList<>();
+        index = 0;
+        while (index >= 0 && index < data.length()) {
+            index = data.indexOfBruteForce(pattern, index);
+            if (index >= 0) {
+                bruteForce.add(index);
+                index++;
+            }
+        }
+
+        List<Integer> indexOf = new ArrayList<>();
+        index = 0;
+        while (index >= 0 && index < data.length()) {
+            index = data.indexOf(pattern, index);
+            if (index >= 0) {
+                indexOf.add(index);
+                index++;
+            }
+        }
+
+        assertEquals(bruteForce, indexOf);
     }
 
     private static List<Long> createRandomLongs(int count)

--- a/src/test/java/io/airlift/slice/TestSliceUtf8.java
+++ b/src/test/java/io/airlift/slice/TestSliceUtf8.java
@@ -1,0 +1,522 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Ints;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.IntStream;
+
+import static io.airlift.slice.SliceUtf8.codePointToUtf8;
+import static io.airlift.slice.SliceUtf8.countCodePoints;
+import static io.airlift.slice.SliceUtf8.getCodePointAt;
+import static io.airlift.slice.SliceUtf8.getCodePointBefore;
+import static io.airlift.slice.SliceUtf8.leftTrim;
+import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
+import static io.airlift.slice.SliceUtf8.lengthOfCodePointFromStartByte;
+import static io.airlift.slice.SliceUtf8.offsetOfCodePoint;
+import static io.airlift.slice.SliceUtf8.reverse;
+import static io.airlift.slice.SliceUtf8.rightTrim;
+import static io.airlift.slice.SliceUtf8.setCodePointAt;
+import static io.airlift.slice.SliceUtf8.substring;
+import static io.airlift.slice.SliceUtf8.toLowerCase;
+import static io.airlift.slice.SliceUtf8.toUpperCase;
+import static io.airlift.slice.SliceUtf8.trim;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.lang.Character.MAX_CODE_POINT;
+import static java.lang.Character.MIN_SURROGATE;
+import static java.lang.Character.SURROGATE;
+import static java.lang.Character.getType;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+
+public class TestSliceUtf8
+{
+    private static final int[] ASCII_CODE_POINTS;
+    private static final String STRING_ASCII_CODE_POINTS;
+    private static final int[] ALL_CODE_POINTS;
+    private static final String STRING_ALL_CODE_POINTS;
+    private static final int[] ALL_CODE_POINTS_RANDOM;
+    private static final String STRING_ALL_CODE_POINTS_RANDOM;
+    
+    private static final byte START_1_BYTE = (byte) 0b0111_1111;
+    private static final byte CONTINUATION_BYTE = (byte) 0b1011_1111;
+    private static final byte START_2_BYTE = (byte) 0b1101_1111;
+    private static final byte START_3_BYTE = (byte) 0b1110_1111;
+    private static final byte START_4_BYTE = (byte) 0b1111_0111;
+    private static final byte START_5_BYTE = (byte) 0b1111_1011;
+    private static final byte START_6_BYTE = (byte) 0b1111_1101;
+    private static final byte INVALID_FF_BYTE = (byte) 0b11111111;
+
+    static {
+        ASCII_CODE_POINTS = IntStream.range(0, 0x7F)
+                .toArray();
+        STRING_ASCII_CODE_POINTS = new String(ASCII_CODE_POINTS, 0, ASCII_CODE_POINTS.length);
+
+        ALL_CODE_POINTS = IntStream.range(0, MAX_CODE_POINT)
+                .filter(codePoint -> getType(codePoint) != SURROGATE)
+                .toArray();
+        STRING_ALL_CODE_POINTS = new String(ALL_CODE_POINTS, 0, ALL_CODE_POINTS.length);
+
+        ALL_CODE_POINTS_RANDOM = Arrays.copyOf(ALL_CODE_POINTS, ALL_CODE_POINTS.length);
+        Collections.shuffle(Arrays.asList(ALL_CODE_POINTS_RANDOM));
+        STRING_ALL_CODE_POINTS_RANDOM = new String(ALL_CODE_POINTS_RANDOM, 0, ALL_CODE_POINTS_RANDOM.length);
+    }
+
+    private static final String STRING_EMPTY = "";
+    private static final String STRING_HELLO = "hello";
+    private static final String STRING_QUADRATICALLY = "Quadratically";
+    private static final String STRING_OESTERREICH = "\u00D6sterreich";
+    private static final String STRING_DULIOE_DULIOE = "Duli\u00F6 duli\u00F6";
+    private static final String STRING_FAITH_HOPE_LOVE = "\u4FE1\u5FF5,\u7231,\u5E0C\u671B";
+    private static final String STRING_NAIVE = "na\u00EFve";
+    private static final String STRING_OO = "\uD801\uDC2Dend";
+
+    private static final byte[] INVALID_UTF8_1 = new byte[] {-127};
+    private static final byte[] INVALID_UTF8_2 = new byte[] {50, -127, 52, 50};
+
+    @Test
+    public void testCodePointCount()
+    {
+        assertCodePointCount(STRING_EMPTY);
+        assertCodePointCount(STRING_HELLO);
+        assertCodePointCount(STRING_QUADRATICALLY);
+        assertCodePointCount(STRING_OESTERREICH);
+        assertCodePointCount(STRING_DULIOE_DULIOE);
+        assertCodePointCount(STRING_FAITH_HOPE_LOVE);
+        assertCodePointCount(STRING_NAIVE);
+        assertCodePointCount(STRING_OO);
+        assertCodePointCount(STRING_ASCII_CODE_POINTS);
+        assertCodePointCount(STRING_ALL_CODE_POINTS);
+        assertCodePointCount(STRING_ALL_CODE_POINTS_RANDOM);
+
+        assertEquals(countCodePoints(wrappedBuffer(START_1_BYTE)), 1);
+        assertEquals(countCodePoints(wrappedBuffer(START_2_BYTE)), 1);
+        assertEquals(countCodePoints(wrappedBuffer(START_3_BYTE)), 1);
+        assertEquals(countCodePoints(wrappedBuffer(START_4_BYTE)), 1);
+        assertEquals(countCodePoints(wrappedBuffer(START_5_BYTE)), 1);
+        assertEquals(countCodePoints(wrappedBuffer(START_6_BYTE)), 1);
+        assertEquals(countCodePoints(wrappedBuffer(INVALID_FF_BYTE)), 1);
+        assertEquals(countCodePoints(wrappedBuffer(CONTINUATION_BYTE)), 0);
+    }
+
+    private static void assertCodePointCount(String string)
+    {
+        assertEquals(countCodePoints(utf8Slice(string)), string.codePoints().count());
+    }
+
+    @Test
+    public void testOffsetByCodePoints()
+    {
+        assertEquals(offsetOfCodePoint(EMPTY_SLICE, 0), -1);
+        assertOffsetByCodePoints(STRING_HELLO);
+        assertOffsetByCodePoints(STRING_QUADRATICALLY);
+        assertOffsetByCodePoints(STRING_OESTERREICH);
+        assertOffsetByCodePoints(STRING_DULIOE_DULIOE);
+        assertOffsetByCodePoints(STRING_FAITH_HOPE_LOVE);
+        assertOffsetByCodePoints(STRING_NAIVE);
+        assertOffsetByCodePoints(STRING_OO);
+        assertOffsetByCodePoints(STRING_ASCII_CODE_POINTS);
+        assertOffsetByCodePoints(STRING_ALL_CODE_POINTS);
+        assertOffsetByCodePoints(STRING_ALL_CODE_POINTS_RANDOM);
+    }
+
+    private static void assertOffsetByCodePoints(String string)
+    {
+        Slice utf8 = utf8Slice(string);
+
+        int codePoints = (int) string.codePoints().count();
+        int lastIndex = 0;
+        int characterIndex = 0;
+        for (int codePointIndex = 0; codePointIndex < codePoints; codePointIndex++) {
+            int expectedIndex = 0;
+
+            // calculate the expected index by searching forward from the last index
+            if (codePointIndex > 0) {
+                expectedIndex = lastIndex + lengthOfCodePoint(string.codePointAt(characterIndex));
+                characterIndex = string.offsetByCodePoints(characterIndex, 1);
+            }
+            // avoid n^2 performance for large test string
+            if (codePointIndex < 10000) {
+                assertEquals(offsetOfCodePoint(utf8, codePointIndex), expectedIndex);
+            }
+
+            if (codePointIndex > 0) {
+                assertEquals(offsetOfCodePoint(utf8, lastIndex, 1), expectedIndex);
+            }
+            lastIndex = expectedIndex;
+        }
+        assertEquals(offsetOfCodePoint(utf8Slice(string), codePoints), -1);
+    }
+
+    @Test
+    public void testSubstring()
+    {
+        assertSubstring(STRING_HELLO);
+        assertSubstring(STRING_QUADRATICALLY);
+        assertSubstring(STRING_OESTERREICH);
+        assertSubstring(STRING_DULIOE_DULIOE);
+        assertSubstring(STRING_FAITH_HOPE_LOVE);
+        assertSubstring(STRING_NAIVE);
+        assertSubstring(STRING_OO);
+        assertSubstring(STRING_ASCII_CODE_POINTS);
+        // substring test over all code points takes too long, so only run it on the tail
+        // that has the largest code points
+        assertSubstring(new String(ALL_CODE_POINTS, ALL_CODE_POINTS.length - 500, 500));
+    }
+
+    private static void assertSubstring(String string)
+    {
+        Slice utf8 = utf8Slice(string);
+
+        int[] codePoints = string.codePoints().toArray();
+        for (int start = 0; start < codePoints.length / 2; start++) {
+            int count = Math.min(20, codePoints.length - start - start - 1);
+            Slice actual = substring(utf8, start, count);
+            Slice expected = wrappedBuffer(new String(codePoints, start, count).getBytes(UTF_8));
+            assertEquals(actual, expected);
+        }
+        assertEquals(substring(utf8, 0, codePoints.length), utf8);
+        assertEquals(substring(utf8, 0, 0), EMPTY_SLICE);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "UTF-8 does not contain 10 code points")
+    public void testSubstringInvalidStart()
+    {
+        substring(utf8Slice(STRING_HELLO), 10, 2);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "UTF-8 does not contain 7 code points")
+    public void testSubstringInvalidLength()
+    {
+        substring(utf8Slice(STRING_HELLO), 0, 7);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "UTF-8 is not well formed")
+    public void testSubstringInvalidUtf8()
+    {
+        substring(wrappedBuffer((byte) 'f', (byte) 'o', (byte) 'o', START_3_BYTE, CONTINUATION_BYTE), 0, 4);
+    }
+
+    @Test
+    public void testReverse()
+    {
+        assertReverse(STRING_HELLO);
+        assertReverse(STRING_QUADRATICALLY);
+        assertReverse(STRING_OESTERREICH);
+        assertReverse(STRING_DULIOE_DULIOE);
+        assertReverse(STRING_FAITH_HOPE_LOVE);
+        assertReverse(STRING_NAIVE);
+        assertReverse(STRING_OO);
+        assertReverse(STRING_ASCII_CODE_POINTS);
+        assertReverse(STRING_ALL_CODE_POINTS);
+    }
+
+    private static void assertReverse(String string)
+    {
+        Slice actualReverse = reverse(utf8Slice(string));
+
+        int[] codePoints = string.codePoints().toArray();
+        codePoints = Ints.toArray(Lists.reverse(Ints.asList(codePoints)));
+        Slice expectedReverse = wrappedBuffer(new String(codePoints, 0, codePoints.length).getBytes(UTF_8));
+
+        assertEquals(actualReverse, expectedReverse);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "UTF-8 is not well formed")
+    public void testReverseInvalidUtf8()
+    {
+        reverse(wrappedBuffer((byte) 'f', (byte) 'o', (byte) 'o', START_3_BYTE, CONTINUATION_BYTE));
+    }
+
+    @Test
+    public void testCaseChange()
+    {
+        assertCaseChange(STRING_ALL_CODE_POINTS);
+        assertCaseChange(STRING_FAITH_HOPE_LOVE);
+        assertCaseChange(STRING_HELLO);
+        assertCaseChange(STRING_QUADRATICALLY);
+        assertCaseChange(STRING_OESTERREICH);
+        assertCaseChange(STRING_DULIOE_DULIOE);
+        assertCaseChange(STRING_FAITH_HOPE_LOVE);
+        assertCaseChange(STRING_NAIVE);
+        assertCaseChange(STRING_OO);
+        assertCaseChange(STRING_ASCII_CODE_POINTS);
+        assertCaseChange(STRING_ALL_CODE_POINTS);
+        assertCaseChange(STRING_ALL_CODE_POINTS_RANDOM);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "UTF-8 sequence truncated")
+    public void testToUpperCaseTruncatedUtf8()
+    {
+        toUpperCase(wrappedBuffer((byte) 'f', (byte) 'o', (byte) 'o', START_3_BYTE, CONTINUATION_BYTE));
+    }
+
+    private static void assertCaseChange(String string)
+    {
+        String expectedLower = lowerByCodePoint(string);
+        Slice actualLower = toLowerCase(utf8Slice(string));
+        assertEquals(actualLower, wrappedBuffer(expectedLower.getBytes(UTF_8)));
+
+        String expectedUpper = upperByCodePoint(string);
+        Slice actualUpper = toUpperCase(utf8Slice(string));
+        assertEquals(actualUpper, wrappedBuffer(expectedUpper.getBytes(UTF_8)));
+
+        // lower the upper and upper the lower
+        // NOTE: not all code points roundtrip, so calculate the expected
+        assertEquals(toLowerCase(actualUpper), wrappedBuffer(lowerByCodePoint(expectedUpper).getBytes(UTF_8)));
+        assertEquals(toUpperCase(actualLower), wrappedBuffer(upperByCodePoint(expectedLower).getBytes(UTF_8)));
+    }
+
+    private static String lowerByCodePoint(String string)
+    {
+        int[] upperCodePoints = string.codePoints().map(Character::toLowerCase).toArray();
+        return new String(upperCodePoints, 0, upperCodePoints.length);
+    }
+
+    private static String upperByCodePoint(String string)
+    {
+        int[] upperCodePoints = string.codePoints().map(Character::toUpperCase).toArray();
+        return new String(upperCodePoints, 0, upperCodePoints.length);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "Illegal start 0xFB of code point")
+    public void testToUpperCase5ByteUtf8()
+    {
+        toUpperCase(wrappedBuffer((byte) 'f', (byte) 'o', (byte) 'o', START_5_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE));
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "Illegal start 0xBF of code point")
+    public void testToUpperCaseStartContinuationUtf8()
+    {
+        toUpperCase(wrappedBuffer((byte) 'f', (byte) 'o', (byte) 'o', CONTINUATION_BYTE, (byte) 'x'));
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "UTF-8 sequence truncated")
+    public void testToLowerCaseTruncatedUtf8()
+    {
+        toLowerCase(wrappedBuffer((byte) 'f', (byte) 'o', (byte) 'o', START_3_BYTE, CONTINUATION_BYTE));
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "Illegal start 0xFB of code point")
+    public void testToLowerCase5ByteUtf8()
+    {
+        toLowerCase(wrappedBuffer((byte) 'f', (byte) 'o', (byte) 'o', START_5_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE));
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "Illegal start 0xBF of code point")
+    public void testToLowerCaseStartContinuationUtf8()
+    {
+        toLowerCase(wrappedBuffer((byte) 'f', (byte) 'o', (byte) 'o', CONTINUATION_BYTE, (byte) 'x'));
+    }
+
+    @Test
+    public void testLeftTrim()
+    {
+        assertLeftTrim("");
+        assertLeftTrim("hello");
+        assertLeftTrim("hello world");
+        assertLeftTrim("hello world  ");
+    }
+
+    private static void assertLeftTrim(String string)
+    {
+        assertEquals(leftTrim(utf8Slice(string)), utf8Slice(string));
+        for (int codePoint : ALL_CODE_POINTS) {
+            if (Character.isWhitespace(codePoint)) {
+                String whitespace = new String(new int[] {codePoint}, 0, 1);
+                assertEquals(leftTrim(utf8Slice(whitespace + string)), utf8Slice(string));
+                assertEquals(leftTrim(utf8Slice(whitespace + "\r\n\t " + whitespace + string)), utf8Slice(string));
+            }
+        }
+    }
+
+    @Test
+    public void testRightTrim()
+    {
+        assertRightTrim("");
+        assertRightTrim("hello");
+        assertRightTrim("hello world");
+        assertRightTrim("  hello world");
+    }
+
+    private static void assertRightTrim(String string)
+    {
+        assertEquals(rightTrim(utf8Slice(string)), utf8Slice(string));
+        for (int codePoint : ALL_CODE_POINTS) {
+            if (Character.isWhitespace(codePoint)) {
+                String whitespace = new String(new int[] {codePoint}, 0, 1);
+                assertEquals(rightTrim(utf8Slice(string + whitespace)), utf8Slice(string));
+                assertEquals(rightTrim(utf8Slice(string + whitespace + "\r\n\t " + whitespace)), utf8Slice(string));
+            }
+        }
+    }
+
+    @Test
+    public void testTrim()
+    {
+        assertTrim("");
+        assertTrim("hello");
+        assertTrim("hello world");
+    }
+
+    private static void assertTrim(String string)
+    {
+        assertEquals(trim(utf8Slice(string)), utf8Slice(string));
+        for (int codePoint : ALL_CODE_POINTS) {
+            if (Character.isWhitespace(codePoint)) {
+                String whitespace = new String(new int[] {codePoint}, 0, 1);
+                assertEquals(trim(utf8Slice(whitespace + string + whitespace)), utf8Slice(string));
+                assertEquals(trim(utf8Slice(whitespace + "\r\n\t " + whitespace + string + whitespace + "\r\n\t " + whitespace)), utf8Slice(string));
+            }
+        }
+    }
+
+    /**
+     * Test invalid UTF8 encodings. We do not expect a 'correct' but none harmful result.
+     */
+    @Test
+    public void testInvalidUtf8()
+    {
+        assertEquals(countCodePoints(wrappedBuffer(INVALID_UTF8_1)), 0);
+        assertEquals(countCodePoints(wrappedBuffer(INVALID_UTF8_2)), 3);
+
+        assertEquals(offsetOfCodePoint(wrappedBuffer(INVALID_UTF8_1), 0), 0);
+        assertEquals(offsetOfCodePoint(wrappedBuffer(INVALID_UTF8_1), 1), -1);
+
+        assertEquals(offsetOfCodePoint(wrappedBuffer(INVALID_UTF8_2), 0), 0);
+        assertEquals(offsetOfCodePoint(wrappedBuffer(INVALID_UTF8_2), 1), 2);
+        assertEquals(offsetOfCodePoint(wrappedBuffer(INVALID_UTF8_2), 2), 3);
+        assertEquals(offsetOfCodePoint(wrappedBuffer(INVALID_UTF8_2), 3), -1);
+    }
+
+    @Test
+    public void testLengthOfCodePoint()
+    {
+        assertEquals(lengthOfCodePointFromStartByte(START_1_BYTE), 1);
+        assertEquals(lengthOfCodePointFromStartByte(START_2_BYTE), 2);
+        assertEquals(lengthOfCodePointFromStartByte(START_3_BYTE), 3);
+        assertEquals(lengthOfCodePointFromStartByte(START_4_BYTE), 4);
+
+        for (int codePoint : ALL_CODE_POINTS) {
+            String string = new String(new int[] {codePoint}, 0, 1);
+            assertEquals(string.codePoints().count(), 1);
+
+            Slice utf8 = wrappedBuffer(string.getBytes(UTF_8));
+            assertEquals(lengthOfCodePoint(codePoint), utf8.length());
+            assertEquals(lengthOfCodePoint(utf8, 0), utf8.length());
+            assertEquals(lengthOfCodePointFromStartByte(utf8.getByte(0)), utf8.length());
+
+            assertEquals(getCodePointAt(utf8, 0), codePoint);
+            assertEquals(getCodePointBefore(utf8, utf8.length()), codePoint);
+
+            assertEquals(codePointToUtf8(codePoint), utf8);
+        }
+    }
+
+    @Test(expectedExceptions = InvalidCodePointException.class, expectedExceptionsMessageRegExp = "Invalid code point 0xFFFFFFFF")
+    public void testLengthOfNegativeCodePoint()
+    {
+        lengthOfCodePoint(-1);
+    }
+
+    @Test(expectedExceptions = InvalidCodePointException.class, expectedExceptionsMessageRegExp = "Invalid code point 0x110000")
+    public void testLengthOfOutOfRangeCodePoint()
+    {
+        lengthOfCodePoint(MAX_CODE_POINT + 1);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "Illegal start 0xBF of code point")
+    public void testLengthOfCodePointContinuationByte()
+    {
+        lengthOfCodePointFromStartByte(CONTINUATION_BYTE);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "Illegal start 0xFB of code point")
+    public void testLengthOfCodePoint4ByteSequence()
+    {
+        lengthOfCodePointFromStartByte(START_5_BYTE);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "Illegal start 0xFD of code point")
+    public void testLengthOfCodePointFEByte()
+    {
+        lengthOfCodePointFromStartByte(START_6_BYTE);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "Illegal start 0xFF of code point")
+    public void testLengthOfCodePointFGByte()
+    {
+        lengthOfCodePointFromStartByte(INVALID_FF_BYTE);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "UTF-8 sequence truncated")
+    public void testCodePointAtTruncated2()
+    {
+        getCodePointAt(wrappedBuffer((byte) 'x', START_2_BYTE), 1);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "UTF-8 sequence truncated")
+    public void testCodePointAtTruncated3()
+    {
+        getCodePointAt(wrappedBuffer((byte) 'x', START_3_BYTE, CONTINUATION_BYTE), 1);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "UTF-8 sequence truncated")
+    public void testCodePointAtTruncated4()
+    {
+        getCodePointAt(wrappedBuffer((byte) 'x', START_4_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE), 1);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "Illegal start 0xFB of code point")
+    public void testCodePointAt5ByteSequence()
+    {
+        getCodePointAt(wrappedBuffer((byte) 'x', START_5_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE), 1);
+    }
+
+    @Test(expectedExceptions = InvalidUtf8Exception.class, expectedExceptionsMessageRegExp = "UTF-8 is not well formed")
+    public void testCodePointBefore5ByteSequence()
+    {
+        getCodePointBefore(wrappedBuffer((byte) 'x', START_5_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE, CONTINUATION_BYTE), 6);
+    }
+
+    @Test(expectedExceptions = InvalidCodePointException.class, expectedExceptionsMessageRegExp = "Invalid code point 0xFFFFFFFF")
+    public void testSetNegativeCodePoint()
+    {
+        setCodePointAt(-1, Slices.allocate(8), 0);
+    }
+    @Test(expectedExceptions = InvalidCodePointException.class, expectedExceptionsMessageRegExp = "Invalid code point 0xD800")
+    public void testSetSurrogateCodePoint()
+    {
+        setCodePointAt(MIN_SURROGATE, Slices.allocate(8), 0);
+    }
+
+    @Test(expectedExceptions = InvalidCodePointException.class, expectedExceptionsMessageRegExp = "Invalid code point 0x110000")
+    public void testSetOutOfRangeCodePoint()
+    {
+        setCodePointAt(MAX_CODE_POINT + 1, Slices.allocate(8), 0);
+    }
+
+    @Test(expectedExceptions = InvalidCodePointException.class, expectedExceptionsMessageRegExp = "Invalid code point 0xFFFFFFBF")
+    public void testSetCodePointContinuationByte()
+    {
+        setCodePointAt(CONTINUATION_BYTE, Slices.allocate(8), 0);
+    }
+
+}


### PR DESCRIPTION
Benchmark results
```
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                     true        2   avgt         5        5.264        0.483    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                     true        5   avgt         5        4.922        0.407    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                     true       10   avgt         5        6.629        0.263    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                     true      100   avgt         5       32.332        0.891    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                     true     1000   avgt         5      217.946       17.012    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                     true    10000   avgt         5     2167.985       81.910    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                    false        2   avgt         5        4.338        0.217    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                    false        5   avgt         5       11.658        0.364    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                    false       10   avgt         5       16.457        0.921    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                    false      100   avgt         5       92.792        4.184    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                    false     1000   avgt         5      803.745       11.548    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkCountCodePoints                    false    10000   avgt         5     8355.725      433.531    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                            true        2   avgt         5       20.901       10.740    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                            true        5   avgt         5       33.384       21.220    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                            true       10   avgt         5       61.011       23.851    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                            true      100   avgt         5      427.053       17.286    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                            true     1000   avgt         5     4158.446      424.360    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                            true    10000   avgt         5    42400.839    10942.289    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                           false        2   avgt         5       41.403       27.100    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                           false        5   avgt         5       56.880       24.005    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                           false       10   avgt         5      103.239       34.702    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                           false      100   avgt         5      710.831       20.477    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                           false     1000   avgt         5     7122.720      358.856    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLeftTrim                           false    10000   avgt         5   101649.618     3738.675    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte      true        2   avgt         5        5.327        0.296    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte      true        5   avgt         5       10.930        0.320    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte      true       10   avgt         5       20.225        0.840    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte      true      100   avgt         5      187.906       64.800    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte      true     1000   avgt         5     1598.730       26.842    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte      true    10000   avgt         5    15742.387      853.695    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte     false        2   avgt         5        8.434        0.358    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte     false        5   avgt         5       18.323        1.291    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte     false       10   avgt         5       34.781        2.343    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte     false      100   avgt         5      360.887       19.849    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte     false     1000   avgt         5     3138.388       76.290    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkLengthOfCodePointFromStartByte     false    10000   avgt         5    50879.856     2758.392    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                  true        2   avgt         5        7.860        0.379    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                  true        5   avgt         5        7.801        0.454    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                  true       10   avgt         5        9.631        0.157    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                  true      100   avgt         5       33.787        1.311    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                  true     1000   avgt         5      231.924        4.757    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                  true    10000   avgt         5     2094.478       32.523    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                 false        2   avgt         5       15.203        0.745    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                 false        5   avgt         5       27.458        1.881    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                 false       10   avgt         5       40.367       10.629    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                 false      100   avgt         5      107.515        5.352    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                 false     1000   avgt         5      847.706      147.243    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkOffsetByCodePoints                 false    10000   avgt         5     7714.655      561.249    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                             true        2   avgt         5       27.706       14.324    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                             true        5   avgt         5       39.282       24.624    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                             true       10   avgt         5       61.571       34.689    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                             true      100   avgt         5      348.024       31.436    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                             true     1000   avgt         5     3320.644      317.888    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                             true    10000   avgt         5    47145.389     7162.010    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                            false        2   avgt         5       28.251       14.266    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                            false        5   avgt         5       47.905       22.201    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                            false       10   avgt         5       70.392       49.835    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                            false      100   avgt         5      565.449      299.421    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                            false     1000   avgt         5     5343.788     2555.660    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkReverse                            false    10000   avgt         5    67555.599    14676.626    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                           true        2   avgt         5       13.274        6.028    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                           true        5   avgt         5       22.778       10.008    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                           true       10   avgt         5       32.094       27.510    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                           true      100   avgt         5      213.380        9.532    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                           true     1000   avgt         5     1894.472       98.399    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                           true    10000   avgt         5    20227.306     1015.801    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                          false        2   avgt         5       35.952       23.220    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                          false        5   avgt         5       58.451       19.854    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                          false       10   avgt         5       58.859       27.906    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                          false      100   avgt         5      767.062       63.887    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                          false     1000   avgt         5     7184.909      291.870    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkRightTrim                          false    10000   avgt         5    86720.593     6585.779    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                           true        2   avgt         5       16.644        7.514    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                           true        5   avgt         5       24.660       10.987    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                           true       10   avgt         5       31.801       22.176    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                           true      100   avgt         5       61.838       23.996    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                           true     1000   avgt         5      299.220       17.071    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                           true    10000   avgt         5     2590.615       86.662    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                          false        2   avgt         5       17.025        4.429    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                          false        5   avgt         5       44.734       24.780    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                          false       10   avgt         5       85.637       22.671    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                          false      100   avgt         5      187.405       19.694    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                          false     1000   avgt         5      984.944       79.446    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkSubstring                          false    10000   avgt         5     9099.247      592.327    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                         true        2   avgt         5       36.988       19.571    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                         true        5   avgt         5       69.404       47.251    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                         true       10   avgt         5      100.714       10.001    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                         true      100   avgt         5      771.862       54.309    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                         true     1000   avgt         5     9208.320      863.557    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                         true    10000   avgt         5    73833.935     5782.127    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                        false        2   avgt         5       68.258        6.927    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                        false        5   avgt         5      127.339        4.060    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                        false       10   avgt         5      251.350       11.612    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                        false      100   avgt         5     2373.579       98.422    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                        false     1000   avgt         5    23098.647      764.618    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToLowerCase                        false    10000   avgt         5   238104.430    13268.704    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                         true        2   avgt         5       37.856       23.958    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                         true        5   avgt         5       67.245       54.394    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                         true       10   avgt         5      103.224       54.001    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                         true      100   avgt         5      713.009       63.180    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                         true     1000   avgt         5     8735.651     1226.680    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                         true    10000   avgt         5    71755.313     3992.698    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                        false        2   avgt         5       76.162       41.506    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                        false        5   avgt         5      157.197       42.894    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                        false       10   avgt         5      275.479       25.238    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                        false      100   avgt         5     2296.063      159.783    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                        false     1000   avgt         5    23477.471     2041.813    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkToUpperCase                        false    10000   avgt         5   237794.031    13939.784    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                                true        2   avgt         5       15.228        1.139    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                                true        5   avgt         5       26.319        1.538    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                                true       10   avgt         5       45.508        1.747    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                                true      100   avgt         5      416.759       16.930    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                                true     1000   avgt         5     3811.637      253.413    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                                true    10000   avgt         5    39724.417    13021.642    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                               false        2   avgt         5       21.034        0.652    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                               false        5   avgt         5       40.319        2.198    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                               false       10   avgt         5       72.650        3.365    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                               false      100   avgt         5      606.472       56.464    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                               false     1000   avgt         5     6318.165      278.271    ns/op
i.a.s.SliceUtf8Benchmark.benchmarkTrim                               false    10000   avgt         5   104226.421     6254.750    ns/op
```