### PR TITLE
Fix invalid mask when computing length of tail in xxhash64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,13 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>net.jpountz.lz4</groupId>
+            <artifactId>lz4</artifactId>
+            <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/src/main/java/io/airlift/slice/XxHash64.java
+++ b/src/main/java/io/airlift/slice/XxHash64.java
@@ -70,7 +70,7 @@ public class XxHash64
 
         // round to the closest 32 byte boundary
         // this is the point up to which {@see #updateBody} processed
-        int index = length & 0xFFFFFF70;
+        int index = length & 0xFFFFFFE0;
 
         while (index <= length - 8) {
             hash = updateTail(hash, unsafe.getLong(base, address + index));

--- a/src/test/java/io/airlift/slice/TestXxHash64.java
+++ b/src/test/java/io/airlift/slice/TestXxHash64.java
@@ -13,6 +13,8 @@
  */
 package io.airlift.slice;
 
+import net.jpountz.xxhash.XXHash64;
+import net.jpountz.xxhash.XXHashFactory;
 import org.testng.annotations.Test;
 
 import static io.airlift.slice.XxHash64.hash;
@@ -56,6 +58,19 @@ public class TestXxHash64
 
         assertEquals(hash(0, buffer), 0x0EAB543384F878ADL);
         assertEquals(hash(PRIME, buffer), 0xCAA65939306F1E21L);
+    }
+
+    @Test
+    public void testMultipleLengths()
+            throws Exception
+    {
+        XXHash64 jpountz = XXHashFactory.fastestInstance().hash64();
+        for (int i = 0; i < 10_000; i++) {
+            byte[] data = new byte[i];
+            long expected = jpountz.hash(data, 0, data.length, 0);
+            long actual = XxHash64.hash(0, Slices.wrappedBuffer(data));
+            assertEquals(actual, expected, "Failed at length: " + i);
+        }
     }
 
     @Test


### PR DESCRIPTION
This causes hashes of buffers longer than 15 bytes to differ from
the canonical implementation. It also makes all buffers of the same
length to hash to the same value for lengths between 16 and 31.