### PR TITLE
Check for overlong UTF8 representation of surrogate code points

### DIFF
--- a/src/main/java/io/airlift/slice/SliceUtf8.java
+++ b/src/main/java/io/airlift/slice/SliceUtf8.java
@@ -433,7 +433,7 @@ public final class SliceUtf8
      * return value means the UTF-8 sequence at the position is valid, and the result
      * is the code point.  A negative return value means the UTF-8 sequence at the
      * position is invalid, and the length of the invalid sequence is the absolute
-     * value of the result.
+     * value of the result.  UTF-8 Overlong encoding is considered as valid in this method.
      * @return the code point or negative the number of bytes in the invalid UTF-8 sequence.
      */
     public static int tryGetCodePointAt(Slice utf8, int position)
@@ -511,11 +511,11 @@ public final class SliceUtf8
                     ((secondByte & 0b0011_1111) << 12) |
                     ((thirdByte & 0b0011_1111) << 6) |
                     (forthByte & 0b0011_1111);
-            // 4 byte code points have a limited valid range
-            if (codePoint < 0x11_0000) {
-                return codePoint;
+            // 4 byte code points have a limited valid range; surrogates are invalid
+            if (codePoint >= 0x11_0000 || (MIN_SURROGATE <= codePoint && codePoint <= MAX_SURROGATE)) {
+                return -4;
             }
-            return -4;
+            return codePoint;
         }
 
         //

--- a/src/test/java/io/airlift/slice/TestSliceUtf8.java
+++ b/src/test/java/io/airlift/slice/TestSliceUtf8.java
@@ -116,6 +116,10 @@ public class TestSliceUtf8
         // min and max surrogate characters
         invalidSequences.add(new byte[] {(byte) 0b11101101, (byte) 0xA0, (byte) 0x80});
         invalidSequences.add(new byte[] {(byte) 0b11101101, (byte) 0xBF, (byte) 0xBF});
+        // overlong encoding of min and max surrogate characters
+        invalidSequences.add(new byte[] {(byte) 0b11110000, (byte) 0x8D, (byte) 0xA0, (byte) 0x80});
+        invalidSequences.add(new byte[] {(byte) 0b11110000, (byte) 0x8D, (byte) 0xBF, (byte) 0xBF});
+
         INVALID_SEQUENCES = invalidSequences.build();
     }
 


### PR DESCRIPTION
Are we sure we want to do this? By documenting that we allow overlong representation, we are explicitly going against Unicode Corrigendum 1 http://www.unicode.org/versions/corrigendum1.html, which forbids decoders from interpreting non-shortest forms. Given airlift slice is a general purpose library, this is probably not a good idea.