### PR TITLE
Check overlong when decoding UTF-8

### DIFF
--- a/src/main/java/io/airlift/slice/SliceUtf8.java
+++ b/src/main/java/io/airlift/slice/SliceUtf8.java
@@ -466,8 +466,10 @@ public final class SliceUtf8
 
         if (length == 2) {
             // 110x_xxxx 10xx_xxxx
-            return ((firstByte & 0b0001_1111) << 6) |
+            int codePoint = ((firstByte & 0b0001_1111) << 6) |
                     (secondByte & 0b0011_1111);
+            // fail if overlong encoding detected
+            return codePoint < 0x80 ? -2 : codePoint;
         }
 
         //
@@ -491,7 +493,8 @@ public final class SliceUtf8
             if (MIN_SURROGATE <= codePoint && codePoint <= MAX_SURROGATE) {
                 return -3;
             }
-            return codePoint;
+            // fail if overlong encoding detected
+            return codePoint < 0x800 ? -3 : codePoint;
         }
 
         //
@@ -511,8 +514,8 @@ public final class SliceUtf8
                     ((secondByte & 0b0011_1111) << 12) |
                     ((thirdByte & 0b0011_1111) << 6) |
                     (forthByte & 0b0011_1111);
-            // 4 byte code points have a limited valid range
-            if (codePoint < 0x11_0000) {
+            // Check for overlong encoding and code points above upper bound of Unicode
+            if (codePoint < 0x11_0000 && codePoint >= 0x1_0000) {
                 return codePoint;
             }
             return -4;

--- a/src/test/java/io/airlift/slice/TestSliceUtf8.java
+++ b/src/test/java/io/airlift/slice/TestSliceUtf8.java
@@ -116,6 +116,17 @@ public class TestSliceUtf8
         // min and max surrogate characters
         invalidSequences.add(new byte[] {(byte) 0b11101101, (byte) 0xA0, (byte) 0x80});
         invalidSequences.add(new byte[] {(byte) 0b11101101, (byte) 0xBF, (byte) 0xBF});
+
+        // check overlong encoding
+        invalidSequences.add(new byte[] {(byte) 0b11000000, (byte) 0xAF}); // 2-byte encoding of 0x2F
+        invalidSequences.add(new byte[] {(byte) 0b11000001, (byte) 0xBF}); // 2-byte encoding of 0x7F
+        invalidSequences.add(new byte[] {(byte) 0b11100000, (byte) 0x81, (byte) 0xBF}); // 3-byte encoding of 0x7F
+        invalidSequences.add(new byte[] {(byte) 0b11100000, (byte) 0x90, (byte) 0x80}); // 3-byte encoding of 0x400
+        invalidSequences.add(new byte[] {(byte) 0b11100000, (byte) 0x9F, (byte) 0xBF}); // 3-byte encoding of 0x7FF
+        invalidSequences.add(new byte[] {(byte) 0b11110000, (byte) 0x8D, (byte) 0xA0, (byte) 0x80}); // 4-byte encoding of 0xD800
+        invalidSequences.add(new byte[] {(byte) 0b11110000, (byte) 0x8D, (byte) 0xBF, (byte) 0xBF}); // 4-byte encoding of 0xDFFF
+        invalidSequences.add(new byte[] {(byte) 0b11110000, (byte) 0x8F, (byte) 0xBF, (byte) 0xBF}); // 4-byte encoding of 0xFFFF
+
         INVALID_SEQUENCES = invalidSequences.build();
     }
 


### PR DESCRIPTION
Fix [prestodb/presto#4503](https://github.com/prestodb/presto/issues/4503)