### PR TITLE
Fix unintuitive performance in ChunkedSliceInput

### DIFF
--- a/src/main/java/io/airlift/slice/ChunkedSliceInput.java
+++ b/src/main/java/io/airlift/slice/ChunkedSliceInput.java
@@ -63,6 +63,11 @@ public final class ChunkedSliceInput
         if (position < 0 || position > globalLength) {
             throw new IndexOutOfBoundsException("Invalid position " + position + " for slice with length " + globalLength);
         }
+        if (position >= globalPosition && position - globalPosition < bufferLength) {
+            // (position - globalPosition) is guaranteed to fit in int type here because of the above condition
+            bufferPosition = (int) (position - globalPosition);
+            return;
+        }
         this.globalPosition = position;
         this.bufferLength = 0;
         this.bufferPosition = 0;

--- a/src/test/java/io/airlift/slice/TestChunkedSliceInput.java
+++ b/src/test/java/io/airlift/slice/TestChunkedSliceInput.java
@@ -13,10 +13,19 @@
  */
 package io.airlift.slice;
 
+import com.google.common.base.Strings;
 import io.airlift.slice.ChunkedSliceInput.BufferReference;
 import io.airlift.slice.ChunkedSliceInput.SliceLoader;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkPositionIndex;
+import static org.testng.Assert.assertEquals;
 
 public class TestChunkedSliceInput
         extends AbstractSliceInputTest
@@ -31,6 +40,7 @@ public class TestChunkedSliceInput
             implements SliceLoader<BufferReference>
     {
         private final Slice data;
+        private final AtomicInteger count = new AtomicInteger(0);
 
         public SliceSliceLoader(Slice data)
         {
@@ -60,12 +70,47 @@ public class TestChunkedSliceInput
         public void load(long position, BufferReference buffer, int length)
         {
             checkPositionIndex((int) (position + length), (int) getSize());
+            count.incrementAndGet();
             this.data.getBytes((int) position, buffer.getSlice(), 0, length);
+        }
+
+        public int getCount()
+        {
+            return count.get();
         }
 
         @Override
         public void close()
         {
         }
+    }
+
+    @Test
+    public void testSetPosition()
+    {
+        // Create a ChunkedSliceInput with 160 bytes, and set bufferSize to 130.
+        // This test read bytes sequentially, but calls setPosition every time.
+        // Only 2 reads should be issued to the underlying SliceLoader. One when
+        // trying to read position 0, and one when trying to read position 130.
+
+        int length = 160;
+        int bufferSize = 130;
+        Slice slice = Slices.utf8Slice(Strings.repeat("0", length));
+        SliceSliceLoader loader = new SliceSliceLoader(slice);
+        ChunkedSliceInput chunkedSliceInput = new ChunkedSliceInput(loader, bufferSize);
+
+        ArrayList<Integer> actual = new ArrayList<>();
+        for (int i = 0; i < length; i++) {
+            chunkedSliceInput.setPosition(i);
+            chunkedSliceInput.readByte();
+            int count = loader.getCount();
+            actual.add(count);
+        }
+
+        List<Integer> expected = IntStream.range(0, length)
+                .map(i -> i < bufferSize ? 1 : 2)
+                .boxed()
+                .collect(Collectors.toList());
+        assertEquals(actual, expected);
     }
 }


### PR DESCRIPTION
When ChunkedSliceInput.setPosition is called, internal buffer is always flushed. This behavior is surprising and unintuitive. It results in significant disk and CPU waste.

cc @martint, @dain