### PR TITLE
Improve performance of compareTo

### DIFF
--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -894,13 +894,9 @@ public final class Slice
         int compareLength = min(length, otherLength);
         while (compareLength >= SIZE_OF_LONG) {
             long thisLong = getLongUnchecked(offset);
-            thisLong = Long.reverseBytes(thisLong);
             long thatLong = that.getLongUnchecked(otherOffset);
-            thatLong = Long.reverseBytes(thatLong);
-
-            int v = compareUnsignedLongs(thisLong, thatLong);
-            if (v != 0) {
-                return v;
+            if (thisLong != thatLong) {
+                return compareUnsignedLongs(Long.reverseBytes(thisLong), Long.reverseBytes(thatLong));
             }
 
             offset += SIZE_OF_LONG;

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -1218,7 +1218,8 @@ public final class Slice
 
     private static int compareUnsignedLongs(long thisLong, long thatLong)
     {
-        return Long.compare(flipUnsignedLong(thisLong), flipUnsignedLong(thatLong));
+        // We know that thisLong and thatLong are not equal
+        return flipUnsignedLong(thisLong) < flipUnsignedLong(thatLong) ? -1 : 1;
     }
 
     private static long flipUnsignedLong(long thisLong)

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -892,28 +892,30 @@ public final class Slice
         that.checkIndexLength(otherOffset, otherLength);
 
         int compareLength = min(length, otherLength);
+        long thisaddress = address + offset;
+        long thataddress = that.address + otherOffset;
         while (compareLength >= SIZE_OF_LONG) {
-            long thisLong = getLongUnchecked(offset);
-            long thatLong = that.getLongUnchecked(otherOffset);
+            long thisLong = unsafe.getLong(base, thisaddress);
+            long thatLong = unsafe.getLong(that.base, thataddress);
             if (thisLong != thatLong) {
                 return compareUnsignedLongs(Long.reverseBytes(thisLong), Long.reverseBytes(thatLong));
             }
 
-            offset += SIZE_OF_LONG;
-            otherOffset += SIZE_OF_LONG;
+            thisaddress += SIZE_OF_LONG;
+            thataddress += SIZE_OF_LONG;
             compareLength -= SIZE_OF_LONG;
         }
 
         while (compareLength > 0) {
-            byte thisByte = getByteUnchecked(offset);
-            byte thatByte = that.getByteUnchecked(otherOffset);
+            byte thisByte = unsafe.getByte(base, thisaddress);
+            byte thatByte = unsafe.getByte(that.base, thataddress);
 
             int v = compareUnsignedBytes(thisByte, thatByte);
             if (v != 0) {
                 return v;
             }
-            offset++;
-            otherOffset++;
+            thisaddress++;
+            thataddress++;
             compareLength--;
         }
 

--- a/src/test/java/io/airlift/slice/BenchmarkSlice.java
+++ b/src/test/java/io/airlift/slice/BenchmarkSlice.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 5000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 5000, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkSlice
+{
+    @Benchmark
+    public Object compareTo(BenchmarkData data)
+            throws Throwable
+    {
+        return data.slice1.compareTo(0, data.slice1.length(), data.slice2, 0, data.slice2.length());
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private Slice slice1 = Slices.allocate(40);
+        private Slice slice2 = Slices.allocate(40);
+
+        @Setup(Level.Invocation)
+        public void setup()
+        {
+            // reset Slice
+            slice1.fill((byte) 0);
+            slice2.fill((byte) 0);
+
+            // Set different byte at random position and random direction
+            final int pos = ThreadLocalRandom.current().nextInt(35);
+            if (ThreadLocalRandom.current().nextBoolean()) {
+                slice1.setByte(pos, 1);
+            }
+            else {
+                slice2.setByte(pos, 1);
+            }
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkSlice().compareTo(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkSlice.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}


### PR DESCRIPTION
This PR improves performance of `compareTo`. This is accomplished by saving the expensive call to `compareUnsignedLongs` for longs that are know to be equal.
This saves 0 to 40 percent of time, depending on the joint portion of the slices. 