### PR TITLE
Refactoring the handling of streams with SliceInput and SliceOutput

### DIFF
--- a/src/main/java/io/airlift/slice/InputStreamSliceInput.java
+++ b/src/main/java/io/airlift/slice/InputStreamSliceInput.java
@@ -95,7 +95,7 @@ public final class InputStreamSliceInput
     public byte readByte()
     {
         ensureAvailable(SIZE_OF_BYTE);
-        byte v = slice.getByte(bufferPosition);
+        byte v = slice.getByteUnchecked(bufferPosition);
         bufferPosition += SIZE_OF_BYTE;
         return v;
     }
@@ -110,7 +110,7 @@ public final class InputStreamSliceInput
     public short readShort()
     {
         ensureAvailable(SIZE_OF_SHORT);
-        short v = slice.getShort(bufferPosition);
+        short v = slice.getShortUnchecked(bufferPosition);
         bufferPosition += SIZE_OF_SHORT;
         return v;
     }
@@ -125,7 +125,7 @@ public final class InputStreamSliceInput
     public int readInt()
     {
         ensureAvailable(SIZE_OF_INT);
-        int v = slice.getInt(bufferPosition);
+        int v = slice.getIntUnchecked(bufferPosition);
         bufferPosition += SIZE_OF_INT;
         return v;
     }
@@ -134,7 +134,7 @@ public final class InputStreamSliceInput
     public long readLong()
     {
         ensureAvailable(SIZE_OF_LONG);
-        long v = slice.getLong(bufferPosition);
+        long v = slice.getLongUnchecked(bufferPosition);
         bufferPosition += SIZE_OF_LONG;
         return v;
     }
@@ -159,7 +159,7 @@ public final class InputStreamSliceInput
         }
 
         assert availableBytes() > 0;
-        int v = slice.getByte(bufferPosition) & 0xFF;
+        int v = slice.getByteUnchecked(bufferPosition) & 0xFF;
         bufferPosition += SIZE_OF_BYTE;
         return v;
     }

--- a/src/main/java/io/airlift/slice/InputStreamSliceInput.java
+++ b/src/main/java/io/airlift/slice/InputStreamSliceInput.java
@@ -13,34 +13,58 @@
  */
 package io.airlift.slice;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.PushbackInputStream;
 
-import static io.airlift.slice.Preconditions.checkNotNull;
+import static io.airlift.slice.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 
 public final class InputStreamSliceInput
         extends SliceInput
 {
-    private final PushbackInputStream pushbackInputStream;
-    private final CountingInputStream countingInputStream;
-    private final LittleEndianDataInputStream dataInputStream;
+    public static final int DEFAULT_BUFFER_SIZE = 128 * 1024;
+    private static final int MINIMUM_CHUNK_SIZE = 4096;
 
-    @SuppressWarnings("IOResourceOpenedButNotSafelyClosed")
+    private final InputStream inputStream;
+
+    private final byte[] buffer;
+    private final Slice slice;
+    /**
+     * Offset of buffer within stream.
+     */
+    private long bufferOffset;
+    /**
+     * Current position for reading from buffer.
+     */
+    private int bufferPosition;
+
+    private int bufferFill;
+
     public InputStreamSliceInput(InputStream inputStream)
     {
-        checkNotNull(inputStream, "inputStream is null");
-        pushbackInputStream = new PushbackInputStream(inputStream);
-        countingInputStream = new CountingInputStream(pushbackInputStream);
-        dataInputStream = new LittleEndianDataInputStream(countingInputStream);
+        this(inputStream, DEFAULT_BUFFER_SIZE);
+    }
+
+    public InputStreamSliceInput(InputStream inputStream, int bufferSize)
+    {
+        checkArgument(bufferSize >= MINIMUM_CHUNK_SIZE, "minimum buffer size of " + MINIMUM_CHUNK_SIZE + " required");
+        if (inputStream == null) {
+            throw new NullPointerException("inputStream is null");
+        }
+
+        this.inputStream = inputStream;
+        this.buffer = new byte[bufferSize];
+        this.slice = Slices.wrappedBuffer(buffer);
     }
 
     @Override
     public long position()
     {
-        return (int) countingInputStream.getCount();
+        return checkedCast(bufferOffset + bufferPosition);
     }
 
     @Override
@@ -52,183 +76,126 @@ public final class InputStreamSliceInput
     @Override
     public boolean isReadable()
     {
-        try {
-            int value = pushbackInputStream.read();
-            if (value == -1) {
-                return false;
-            }
-            pushbackInputStream.unread(value);
-            return true;
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+        return available() > 0;
     }
 
     @Override
     public int skipBytes(int n)
     {
-        try {
-            return dataInputStream.skipBytes(n);
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
-    }
-
-    @Override
-    public float readFloat()
-    {
-        try {
-            return dataInputStream.readFloat();
-        }
-        catch (EOFException e) {
-            throw new IndexOutOfBoundsException();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
-    }
-
-    @Override
-    public double readDouble()
-    {
-        try {
-            return dataInputStream.readDouble();
-        }
-        catch (EOFException e) {
-            throw new IndexOutOfBoundsException();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
-    }
-
-    @Override
-    public int readUnsignedByte()
-    {
-        try {
-            return dataInputStream.readUnsignedByte();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
-    }
-
-    @Override
-    public int readUnsignedShort()
-    {
-        try {
-            return dataInputStream.readUnsignedShort();
-        }
-        catch (EOFException e) {
-            throw new IndexOutOfBoundsException();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
-    }
-
-    @Override
-    public int readInt()
-    {
-        try {
-            return dataInputStream.readInt();
-        }
-        catch (EOFException e) {
-            throw new IndexOutOfBoundsException();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
-    }
-
-    @Override
-    public long readLong()
-    {
-        try {
-            return dataInputStream.readLong();
-        }
-        catch (EOFException e) {
-            throw new IndexOutOfBoundsException();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
-    }
-
-    @Override
-    public short readShort()
-    {
-        try {
-            return dataInputStream.readShort();
-        }
-        catch (EOFException e) {
-            throw new IndexOutOfBoundsException();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
-    }
-
-    @Override
-    public byte readByte()
-    {
-        try {
-            return dataInputStream.readByte();
-        }
-        catch (EOFException e) {
-            throw new IndexOutOfBoundsException();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+        return (int) skip(n);
     }
 
     @Override
     public boolean readBoolean()
     {
-        try {
-            return dataInputStream.readBoolean();
-        }
-        catch (EOFException e) {
-            throw new IndexOutOfBoundsException();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+        return readByte() != 0;
+    }
+
+    @Override
+    public byte readByte()
+    {
+        ensureAvailable(SIZE_OF_BYTE);
+        byte v = slice.getByte(bufferPosition);
+        bufferPosition += SIZE_OF_BYTE;
+        return v;
+    }
+
+    @Override
+    public int readUnsignedByte()
+    {
+        return readByte() & 0xFF;
+    }
+
+    @Override
+    public short readShort()
+    {
+        ensureAvailable(SIZE_OF_SHORT);
+        short v = slice.getShort(bufferPosition);
+        bufferPosition += SIZE_OF_SHORT;
+        return v;
+    }
+
+    @Override
+    public int readUnsignedShort()
+    {
+        return readShort() & 0xFFFF;
+    }
+
+    @Override
+    public int readInt()
+    {
+        ensureAvailable(SIZE_OF_INT);
+        int v = slice.getInt(bufferPosition);
+        bufferPosition += SIZE_OF_INT;
+        return v;
+    }
+
+    @Override
+    public long readLong()
+    {
+        ensureAvailable(SIZE_OF_LONG);
+        long v = slice.getLong(bufferPosition);
+        bufferPosition += SIZE_OF_LONG;
+        return v;
+    }
+
+    @Override
+    public float readFloat()
+    {
+        return Float.intBitsToFloat(readInt());
+    }
+
+    @Override
+    public double readDouble()
+    {
+        return Double.longBitsToDouble(readLong());
     }
 
     @Override
     public int read()
     {
-        try {
-            return dataInputStream.read();
+        if (available() == 0) {
+            return -1;
         }
-        catch (EOFException e) {
-            throw new IndexOutOfBoundsException();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+
+        assert availableBytes() > 0;
+        int v = slice.getByte(bufferPosition) & 0xFF;
+        bufferPosition += SIZE_OF_BYTE;
+        return v;
     }
 
     @Override
-    public int read(byte[] b, int off, int len)
+    public int read(byte[] destination, int destinationIndex, int length)
     {
-        try {
-            return dataInputStream.read(b, off, len);
+        if (available() == 0) {
+            return -1;
         }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+
+        assert availableBytes() > 0;
+        int batch = Math.min(availableBytes(), length);
+        slice.getBytes(bufferPosition, destination, destinationIndex, batch);
+        bufferPosition += batch;
+        return batch;
     }
 
     @Override
-    public long skip(long n)
+    public long skip(long length)
     {
+        int availableBytes = availableBytes();
+        // is skip within the current buffer?
+        if (availableBytes >= length) {
+            bufferPosition += length;
+            return length;
+        }
+
+        // drop current buffer
+        bufferPosition = bufferFill;
+
         try {
-            return dataInputStream.skip(n);
+            // skip the rest in inputStream
+            long inputStreamSkip = inputStream.skip(length - availableBytes);
+            bufferOffset += inputStreamSkip;
+            return availableBytes + inputStreamSkip;
         }
         catch (IOException e) {
             throw new RuntimeIOException(e);
@@ -238,19 +205,18 @@ public final class InputStreamSliceInput
     @Override
     public int available()
     {
-        try {
-            return countingInputStream.available();
+        if (bufferPosition < bufferFill) {
+            return availableBytes();
         }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+
+        return fillBuffer();
     }
 
     @Override
     public void close()
     {
         try {
-            dataInputStream.close();
+            inputStream.close();
         }
         catch (IOException e) {
             throw new RuntimeIOException(e);
@@ -260,18 +226,15 @@ public final class InputStreamSliceInput
     @Override
     public void readBytes(byte[] destination, int destinationIndex, int length)
     {
-        try {
-            while (length > 0) {
-                int bytesRead = dataInputStream.read(destination, destinationIndex, length);
-                if (bytesRead < 0) {
-                    throw new IndexOutOfBoundsException("End of stream");
-                }
-                length -= bytesRead;
-                destinationIndex += bytesRead;
-            }
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
+        while (length > 0) {
+            int batch = Math.min(availableBytes(), length);
+            slice.getBytes(bufferPosition, destination, destinationIndex, batch);
+
+            bufferPosition += batch;
+            destinationIndex += batch;
+            length -= batch;
+
+            ensureAvailable(Math.min(length, MINIMUM_CHUNK_SIZE));
         }
     }
 
@@ -281,30 +244,24 @@ public final class InputStreamSliceInput
         if (length == 0) {
             return Slices.EMPTY_SLICE;
         }
-        try {
-            Slice newSlice = Slices.allocate(length);
-            newSlice.setBytes(0, countingInputStream, length);
-            return newSlice;
-        }
-        catch (EOFException e) {
-            throw new IndexOutOfBoundsException();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+
+        Slice newSlice = Slices.allocate(length);
+        readBytes(newSlice, 0, length);
+        return newSlice;
     }
 
     @Override
     public void readBytes(Slice destination, int destinationIndex, int length)
     {
-        try {
-            destination.setBytes(destinationIndex, countingInputStream, length);
-        }
-        catch (EOFException e) {
-            throw new IndexOutOfBoundsException();
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
+        while (length > 0) {
+            int batch = Math.min(availableBytes(), length);
+            slice.getBytes(bufferPosition, destination, destinationIndex, batch);
+
+            bufferPosition += batch;
+            destinationIndex += batch;
+            length -= batch;
+
+            ensureAvailable(Math.min(length, MINIMUM_CHUNK_SIZE));
         }
     }
 
@@ -312,12 +269,65 @@ public final class InputStreamSliceInput
     public void readBytes(OutputStream out, int length)
             throws IOException
     {
-        try {
-            SliceStreamUtils.copyStreamFully(this, out, length);
+        while (length > 0) {
+            int batch = Math.min(availableBytes(), length);
+            out.write(buffer, bufferPosition, batch);
+
+            bufferPosition += batch;
+            length -= batch;
+
+            ensureAvailable(Math.min(length, MINIMUM_CHUNK_SIZE));
         }
-        catch (EOFException e) {
-            // EOFException is thrown if this stream does not have the requested data available
-            throw new IndexOutOfBoundsException();
+    }
+
+    private int availableBytes()
+    {
+        return bufferFill - bufferPosition;
+    }
+
+    private void ensureAvailable(int size)
+    {
+        if (bufferPosition + size < bufferFill) {
+            return;
         }
+
+        if (fillBuffer() < size) {
+            throw new IndexOutOfBoundsException("End of stream");
+        }
+    }
+
+    private int fillBuffer()
+    {
+        // Keep the rest
+        int rest = bufferFill - bufferPosition;
+        // Use System.arraycopy for small copies
+        System.arraycopy(buffer, bufferPosition, buffer, 0, rest);
+
+        bufferFill = rest;
+        bufferOffset += bufferPosition;
+        bufferPosition = 0;
+        // Fill buffer with a minimum of bytes
+        while (bufferFill < MINIMUM_CHUNK_SIZE) {
+            try {
+                int bytesRead = inputStream.read(buffer, bufferFill, buffer.length - bufferFill);
+                if (bytesRead < 0) {
+                    break;
+                }
+
+                bufferFill += bytesRead;
+            }
+            catch (IOException e) {
+                throw new RuntimeIOException(e);
+            }
+        }
+
+        return bufferFill;
+    }
+
+    private static int checkedCast(long value)
+    {
+        int result = (int) value;
+        checkArgument(result == value, "Size is greater than maximum int value");
+        return result;
     }
 }

--- a/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
+++ b/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
@@ -122,7 +122,7 @@ public final class OutputStreamSliceOutput
     public void writeByte(int value)
     {
         ensureWritableBytes(SIZE_OF_BYTE);
-        slice.setByte(bufferPosition, value);
+        slice.setByteUnchecked(bufferPosition, value);
         bufferPosition += SIZE_OF_BYTE;
     }
 
@@ -130,7 +130,7 @@ public final class OutputStreamSliceOutput
     public void writeShort(int value)
     {
         ensureWritableBytes(SIZE_OF_SHORT);
-        slice.setShort(bufferPosition, value);
+        slice.setShortUnchecked(bufferPosition, value);
         bufferPosition += SIZE_OF_SHORT;
     }
 
@@ -138,7 +138,7 @@ public final class OutputStreamSliceOutput
     public void writeInt(int value)
     {
         ensureWritableBytes(SIZE_OF_INT);
-        slice.setInt(bufferPosition, value);
+        slice.setIntUnchecked(bufferPosition, value);
         bufferPosition += SIZE_OF_INT;
     }
 
@@ -146,7 +146,7 @@ public final class OutputStreamSliceOutput
     public void writeLong(long value)
     {
         ensureWritableBytes(SIZE_OF_LONG);
-        slice.setLong(bufferPosition, value);
+        slice.setLongUnchecked(bufferPosition, value);
         bufferPosition += SIZE_OF_LONG;
     }
 

--- a/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
+++ b/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
@@ -19,38 +19,67 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 
 import static io.airlift.slice.Preconditions.checkArgument;
-import static io.airlift.slice.Preconditions.checkNotNull;
+import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_INT;
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 
-public class OutputStreamSliceOutput
+public final class OutputStreamSliceOutput
         extends SliceOutput
 {
+    public static final int DEFAULT_BUFFER_SIZE = 128 * 1024;
+
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(OutputStreamSliceOutput.class).instanceSize();
+    private static final int MINIMUM_CHUNK_SIZE = 4096;
 
-    private final CountingOutputStream countingOutputStream; // Used only to track byte usage
-    private final LittleEndianDataOutputStream dataOutputStream;
+    private final OutputStream outputStream;
 
-    @SuppressWarnings("IOResourceOpenedButNotSafelyClosed")
-    public OutputStreamSliceOutput(OutputStream outputStream)
+    private final Slice slice;
+    private final byte[] buffer;
+
+    /**
+     * Offset of buffer within stream.
+     */
+    private long bufferOffset;
+    /**
+     * Current position for writing in buffer.
+     */
+    private int bufferPosition;
+
+    public OutputStreamSliceOutput(OutputStream inputStream)
     {
-        checkNotNull(outputStream, "outputStream is null");
-        countingOutputStream = new CountingOutputStream(outputStream);
-        dataOutputStream = new LittleEndianDataOutputStream(countingOutputStream);
+        this(inputStream, DEFAULT_BUFFER_SIZE);
+    }
+
+    public OutputStreamSliceOutput(OutputStream outputStream, int bufferSize)
+    {
+        checkArgument(bufferSize >= MINIMUM_CHUNK_SIZE, "minimum buffer size of " + MINIMUM_CHUNK_SIZE + " required");
+        if (outputStream == null) {
+            throw new NullPointerException("outputStream is null");
+        }
+
+        this.outputStream = outputStream;
+        this.buffer = new byte[bufferSize];
+        this.slice = Slices.wrappedBuffer(buffer);
     }
 
     @Override
     public void flush()
             throws IOException
     {
-        countingOutputStream.flush();
+        flushBufferToOutputStream();
+        outputStream.flush();
     }
 
     @Override
     public void close()
             throws IOException
     {
-        countingOutputStream.close();
+        flushBufferToOutputStream();
+        outputStream.close();
     }
 
     @Override
@@ -68,16 +97,13 @@ public class OutputStreamSliceOutput
     @Override
     public int size()
     {
-        return checkedCast(countingOutputStream.getCount());
+        return checkedCast(bufferOffset + bufferPosition);
     }
 
-    /**
-     * Note: This does not include the size of the nested OutputStream.
-     */
     @Override
     public int getRetainedSize()
     {
-        return INSTANCE_SIZE;
+        return slice.getRetainedSize() + INSTANCE_SIZE;
     }
 
     @Override
@@ -95,67 +121,45 @@ public class OutputStreamSliceOutput
     @Override
     public void writeByte(int value)
     {
-        try {
-            dataOutputStream.writeByte(value);
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+        ensureWritableBytes(SIZE_OF_BYTE);
+        slice.setByte(bufferPosition, value);
+        bufferPosition += SIZE_OF_BYTE;
     }
 
     @Override
     public void writeShort(int value)
     {
-        try {
-            dataOutputStream.writeShort(value);
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+        ensureWritableBytes(SIZE_OF_SHORT);
+        slice.setShort(bufferPosition, value);
+        bufferPosition += SIZE_OF_SHORT;
     }
 
     @Override
     public void writeInt(int value)
     {
-        try {
-            dataOutputStream.writeInt(value);
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+        ensureWritableBytes(SIZE_OF_INT);
+        slice.setInt(bufferPosition, value);
+        bufferPosition += SIZE_OF_INT;
     }
 
     @Override
     public void writeLong(long value)
     {
-        try {
-            dataOutputStream.writeLong(value);
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+        ensureWritableBytes(SIZE_OF_LONG);
+        slice.setLong(bufferPosition, value);
+        bufferPosition += SIZE_OF_LONG;
     }
 
     @Override
     public void writeFloat(float value)
     {
-        try {
-            dataOutputStream.writeFloat(value);
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+        writeInt(Float.floatToIntBits(value));
     }
 
     @Override
     public void writeDouble(double value)
     {
-        try {
-            dataOutputStream.writeDouble(value);
-        }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
-        }
+        writeLong(Double.doubleToLongBits(value));
     }
 
     @Override
@@ -167,11 +171,16 @@ public class OutputStreamSliceOutput
     @Override
     public void writeBytes(Slice source, int sourceIndex, int length)
     {
-        try {
-            source.getBytes(sourceIndex, dataOutputStream, length);
+        // Write huge chunks direct to OutputStream
+        if (length >= MINIMUM_CHUNK_SIZE) {
+            flushBufferToOutputStream();
+            writeToOutputStream(source, sourceIndex, length);
+            bufferOffset += length;
         }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
+        else {
+            ensureWritableBytes(length);
+            slice.setBytes(bufferPosition, source, sourceIndex, length);
+            bufferPosition += length;
         }
     }
 
@@ -184,11 +193,16 @@ public class OutputStreamSliceOutput
     @Override
     public void writeBytes(byte[] source, int sourceIndex, int length)
     {
-        try {
-            dataOutputStream.write(source, sourceIndex, length);
+        // Write huge chunks direct to OutputStream
+        if (length >= MINIMUM_CHUNK_SIZE) {
+            flushBufferToOutputStream();
+            writeToOutputStream(source, sourceIndex, length);
+            bufferOffset += length;
         }
-        catch (IOException e) {
-            throw new RuntimeIOException(e);
+        else {
+            ensureWritableBytes(length);
+            slice.setBytes(bufferPosition, source, sourceIndex, length);
+            bufferPosition += length;
         }
     }
 
@@ -196,7 +210,25 @@ public class OutputStreamSliceOutput
     public void writeBytes(InputStream in, int length)
             throws IOException
     {
-        SliceStreamUtils.copyStreamFully(in, this, length);
+        while (length > 0) {
+            int batch = ensureBatchSize(length);
+            slice.setBytes(bufferPosition, in, batch);
+            bufferPosition += batch;
+            length -= batch;
+        }
+    }
+
+    @Override
+    public void writeZero(int length)
+    {
+        checkArgument(length >= 0, "length must be 0 or greater than 0.");
+
+        while (length > 0) {
+            int batch = ensureBatchSize(length);
+            Arrays.fill(buffer, bufferPosition, bufferPosition + batch, (byte) 0);
+            bufferPosition += batch;
+            length -= batch;
+        }
     }
 
     @Override
@@ -276,11 +308,51 @@ public class OutputStreamSliceOutput
     @Override
     public String toString()
     {
-        StringBuilder builder = new StringBuilder("BasicSliceOutput{");
-        builder.append("countingOutputStream=").append(countingOutputStream);
-        builder.append(", dataOutputStream=").append(dataOutputStream);
+        StringBuilder builder = new StringBuilder("OutputStreamSliceOutputAdapter{");
+        builder.append("outputStream=").append(outputStream);
+        builder.append("bufferSize=").append(slice.length());
         builder.append('}');
         return builder.toString();
+    }
+
+    private void ensureWritableBytes(int minWritableBytes)
+    {
+        if (bufferPosition + minWritableBytes > slice.length()) {
+            flushBufferToOutputStream();
+        }
+    }
+
+    private int ensureBatchSize(int length)
+    {
+        ensureWritableBytes(Math.min(MINIMUM_CHUNK_SIZE, length));
+        return Math.min(length, slice.length() - bufferPosition);
+    }
+
+    private void flushBufferToOutputStream()
+    {
+        writeToOutputStream(buffer, 0, bufferPosition);
+        bufferOffset += bufferPosition;
+        bufferPosition = 0;
+    }
+
+    private void writeToOutputStream(byte[] source, int sourceIndex, int length)
+    {
+        try {
+            outputStream.write(source, sourceIndex, length);
+        }
+        catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    private void writeToOutputStream(Slice source, int sourceIndex, int length)
+    {
+        try {
+            source.getBytes(sourceIndex, outputStream, length);
+        }
+        catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
     }
 
     private static int checkedCast(long value)

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -622,6 +622,11 @@ public final class Slice
     public void setLong(int index, long value)
     {
         checkIndexLength(index, SIZE_OF_LONG);
+        setLongUnchecked(index, value);
+    }
+
+    void setLongUnchecked(int index, long value)
+    {
         unsafe.putLong(base, address + index, value);
     }
 

--- a/src/test/java/io/airlift/slice/TestInputStreamSliceInput.java
+++ b/src/test/java/io/airlift/slice/TestInputStreamSliceInput.java
@@ -13,7 +13,11 @@
  */
 package io.airlift.slice;
 
+import org.testng.annotations.Test;
+
 import java.io.ByteArrayInputStream;
+
+import static org.testng.Assert.assertEquals;
 
 public class TestInputStreamSliceInput
         extends AbstractSliceInputTest
@@ -21,11 +25,134 @@ public class TestInputStreamSliceInput
     @Override
     protected SliceInput createSliceInput(Slice slice)
     {
-        return new InputStreamSliceInput(new ByteArrayInputStream(slice.getBytes()));
+        return buildSliceInput(slice.getBytes());
     }
 
     @Override
     protected void testReadReverse(SliceInputTester tester, Slice slice)
     {
+    }
+
+    @Test
+    public void testEmptyInput()
+            throws Exception
+    {
+        SliceInput input = buildSliceInput(new byte[0]);
+        assertEquals(input.position(), 0);
+    }
+
+    @Test
+    public void testEmptyRead()
+            throws Exception
+    {
+        SliceInput input = buildSliceInput(new byte[0]);
+        assertEquals(input.read(), -1);
+    }
+
+    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    public void testReadByteBeyondEnd()
+            throws Exception
+    {
+        SliceInput input = buildSliceInput(new byte[0]);
+        input.readByte();
+    }
+
+    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    public void testReadShortBeyondEnd()
+            throws Exception
+    {
+        SliceInput input = buildSliceInput(new byte[1]);
+        input.readShort();
+    }
+
+    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    public void testReadIntBeyondEnd()
+            throws Exception
+    {
+        SliceInput input = buildSliceInput(new byte[3]);
+        input.readInt();
+    }
+
+    @Test(expectedExceptions = IndexOutOfBoundsException.class)
+    public void testReadLongBeyondEnd()
+            throws Exception
+    {
+        SliceInput input = buildSliceInput(new byte[7]);
+        input.readLong();
+    }
+
+    @Test
+    public void testEncodingBoolean()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {1}).readBoolean(), true);
+        assertEquals(buildSliceInput(new byte[] {0}).readBoolean(), false);
+    }
+
+    @Test
+    public void testEncodingByte()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {92}).readByte(), 92);
+        assertEquals(buildSliceInput(new byte[] {-100}).readByte(), -100);
+        assertEquals(buildSliceInput(new byte[] {-17}).readByte(), -17);
+
+        assertEquals(buildSliceInput(new byte[] {92}).readUnsignedByte(), 92);
+        assertEquals(buildSliceInput(new byte[] {-100}).readUnsignedByte(), 156);
+        assertEquals(buildSliceInput(new byte[] {-17}).readUnsignedByte(), 239);
+    }
+
+    @Test
+    public void testEncodingShort()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {109, 92}).readShort(), 23661);
+        assertEquals(buildSliceInput(new byte[] {109, -100}).readShort(), -25491);
+        assertEquals(buildSliceInput(new byte[] {-52, -107}).readShort(), -27188);
+
+        assertEquals(buildSliceInput(new byte[] {109, -100}).readUnsignedShort(), 40045);
+        assertEquals(buildSliceInput(new byte[] {-52, -107}).readUnsignedShort(), 38348);
+    }
+
+    @Test
+    public void testEncodingInteger()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {109, 92, 75, 58}).readInt(), 978017389);
+        assertEquals(buildSliceInput(new byte[] {-16, -60, -120, -1}).readInt(), -7813904);
+    }
+
+    @Test
+    public void testEncodingLong()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {49, -114, -96, -23, -32, -96, -32, 127}).readLong(), 9214541725452766769L);
+        assertEquals(buildSliceInput(new byte[] {109, 92, 75, 58, 18, 120, -112, -17}).readLong(), -1184314682315678611L);
+    }
+
+    @Test
+    public void testEncodingDouble()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {31, -123, -21, 81, -72, 30, 9, 64}).readDouble(), 3.14);
+        assertEquals(buildSliceInput(new byte[] {0, 0, 0, 0, 0, 0, -8, 127}).readDouble(), Double.NaN);
+        assertEquals(buildSliceInput(new byte[] {0, 0, 0, 0, 0, 0, -16, -1}).readDouble(), Double.NEGATIVE_INFINITY);
+        assertEquals(buildSliceInput(new byte[] {0, 0, 0, 0, 0, 0, -16, 127}).readDouble(), Double.POSITIVE_INFINITY);
+    }
+
+    @Test
+    public void testEncodingFloat()
+            throws Exception
+    {
+        assertEquals(buildSliceInput(new byte[] {-61, -11, 72, 64}).readFloat(), 3.14f);
+        assertEquals(buildSliceInput(new byte[] {0, 0, -64, 127}).readFloat(), Float.NaN);
+        assertEquals(buildSliceInput(new byte[] {0, 0, -128, -1}).readFloat(), Float.NEGATIVE_INFINITY);
+        assertEquals(buildSliceInput(new byte[] {0, 0, -128, 127}).readFloat(), Float.POSITIVE_INFINITY);
+    }
+
+    private SliceInput buildSliceInput(byte[] bytes)
+    {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
+        return new InputStreamSliceInput(inputStream, 16 * 1024);
     }
 }

--- a/src/test/java/io/airlift/slice/TestOutputStreamSliceOutput.java
+++ b/src/test/java/io/airlift/slice/TestOutputStreamSliceOutput.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestOutputStreamSliceOutput
+{
+    @Test
+    public void testEncodingBoolean()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeBoolean(true),
+                new byte[] {1});
+        assertEncoding(sliceOutput -> sliceOutput.writeBoolean(false),
+                new byte[] {0});
+    }
+
+    @Test
+    public void testEncodingByte()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeByte(92),
+                new byte[] {92});
+        assertEncoding(sliceOutput -> sliceOutput.writeByte(156),
+                new byte[] {-100});
+        assertEncoding(sliceOutput -> sliceOutput.writeByte(-17),
+                new byte[] {-17});
+    }
+
+    @Test
+    public void testEncodingShort()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeShort(23661),
+                new byte[] {109, 92});
+        assertEncoding(sliceOutput -> sliceOutput.writeShort(40045),
+                new byte[] {109, -100});
+        assertEncoding(sliceOutput -> sliceOutput.writeShort(-27188),
+                new byte[] {-52, -107});
+    }
+
+    @Test
+    public void testEncodingInteger()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeInt(978017389),
+                new byte[] {109, 92, 75, 58});
+        assertEncoding(sliceOutput -> sliceOutput.writeInt(-7813904),
+                new byte[] {-16, -60, -120, -1});
+    }
+
+    @Test
+    public void testEncodingLong()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeLong(9214541725452766769L),
+                new byte[] {49, -114, -96, -23, -32, -96, -32, 127});
+        assertEncoding(sliceOutput -> sliceOutput.writeLong(-1184314682315678611L),
+                new byte[] {109, 92, 75, 58, 18, 120, -112, -17});
+    }
+
+    @Test
+    public void testEncodingDouble()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeDouble(3.14),
+                new byte[] {31, -123, -21, 81, -72, 30, 9, 64});
+        assertEncoding(sliceOutput -> sliceOutput.writeDouble(Double.NaN),
+                new byte[] {0, 0, 0, 0, 0, 0, -8, 127});
+        assertEncoding(sliceOutput -> sliceOutput.writeDouble(Double.NEGATIVE_INFINITY),
+                new byte[] {0, 0, 0, 0, 0, 0, -16, -1});
+        assertEncoding(sliceOutput -> sliceOutput.writeDouble(Double.POSITIVE_INFINITY),
+                new byte[] {0, 0, 0, 0, 0, 0, -16, 127});
+    }
+
+    @Test
+    public void testEncodingFloat()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeFloat(3.14f),
+                new byte[] {-61, -11, 72, 64});
+        assertEncoding(sliceOutput -> sliceOutput.writeFloat(Float.NaN),
+                new byte[] {0, 0, -64, 127});
+        assertEncoding(sliceOutput -> sliceOutput.writeFloat(Float.NEGATIVE_INFINITY),
+                new byte[] {0, 0, -128, -1});
+        assertEncoding(sliceOutput -> sliceOutput.writeFloat(Float.POSITIVE_INFINITY),
+                new byte[] {0, 0, -128, 127});
+    }
+
+    @Test
+    public void testEncodingBytes()
+            throws Exception
+    {
+        byte[] data = new byte[18000];
+        ThreadLocalRandom.current().nextBytes(data);
+
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 0), Arrays.copyOfRange(data, 0, 0));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 3), Arrays.copyOfRange(data, 0, 3));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 370), Arrays.copyOfRange(data, 0, 370));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 4095), Arrays.copyOfRange(data, 0, 4095));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 4096), Arrays.copyOfRange(data, 0, 4096));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 12348), Arrays.copyOfRange(data, 0, 12348));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 16384), Arrays.copyOfRange(data, 0, 16384));
+        assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 18000), Arrays.copyOfRange(data, 0, 18000));
+    }
+
+    @Test
+    public void testEncodingSlice()
+            throws Exception
+    {
+        byte[] data = new byte[18000];
+        ThreadLocalRandom.current().nextBytes(data);
+        Slice slice = Slices.wrappedBuffer(data);
+
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 0), Arrays.copyOfRange(data, 0, 0));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 3), Arrays.copyOfRange(data, 0, 3));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 370), Arrays.copyOfRange(data, 0, 370));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 4095), Arrays.copyOfRange(data, 0, 4095));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 4096), Arrays.copyOfRange(data, 0, 4096));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 12348), Arrays.copyOfRange(data, 0, 12348));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 16384), Arrays.copyOfRange(data, 0, 16384));
+        assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 18000), Arrays.copyOfRange(data, 0, 18000));
+    }
+
+    @Test
+    public void testWriteZero()
+            throws Exception
+    {
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(0), new byte[0]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(1), new byte[1]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(2), new byte[2]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(3), new byte[3]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(4), new byte[4]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(6), new byte[6]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(7), new byte[7]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(8), new byte[8]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(9), new byte[9]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(16), new byte[16]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(22), new byte[22]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(227), new byte[227]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(4227), new byte[4227]);
+        assertEncoding(sliceOutput -> sliceOutput.writeZero(18349), new byte[18349]);
+    }
+
+    /**
+     * Asserting different offsets of operations.
+     */
+    private void assertEncoding(Consumer<SliceOutput> operations, byte... expected)
+            throws IOException
+    {
+        assertEncoding(operations, 0, expected);
+        assertEncoding(operations, 1, expected);
+        assertEncoding(operations, 2, expected);
+        assertEncoding(operations, 3, expected);
+        assertEncoding(operations, 4, expected);
+        assertEncoding(operations, 7, expected);
+        assertEncoding(operations, 8, expected);
+        assertEncoding(operations, 16, expected);
+        assertEncoding(operations, 511, expected);
+        assertEncoding(operations, 12000, expected);
+        assertEncoding(operations, 13000, expected);
+        assertEncoding(operations, 16000, expected);
+        assertEncoding(operations, 16380, expected);
+        assertEncoding(operations, 16383, expected);
+        assertEncoding(operations, 16384, expected);
+        assertEncoding(operations, 18349, expected);
+    }
+
+    private void assertEncoding(Consumer<SliceOutput> operations, int offset, byte... output)
+            throws IOException
+    {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (SliceOutput sliceOutput = new OutputStreamSliceOutput(byteArrayOutputStream, 16384)) {
+            sliceOutput.writeZero(offset);
+            operations.accept(sliceOutput);
+            assertEquals(sliceOutput.size(), offset + output.length);
+        }
+
+        byte[] expected = new byte[offset + output.length];
+        System.arraycopy(output, 0, expected, offset, output.length);
+        assertEquals(byteArrayOutputStream.toByteArray(), expected);
+    }
+}


### PR DESCRIPTION
This PR refactors the handling of streams in `InputStreamSliceInput` and `OutputStreamSliceOutput `to use a slice as buffer for increased performance.
It should be noted that after this change, you have to call at least `flush` if the `SliceOutput `is not closed because it contains a buffer. This occurs, for example, in `PagesResponseWriter` from `presto` where the `OutputStream `ist wrapped with a `OutputStreamSliceOutput  `but not closed.