### PR TITLE
Improve performance of equals and equalsUnchecked

### DIFF
--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -962,31 +962,7 @@ public final class Slice
             return false;
         }
 
-        int offset = 0;
-        int length = size;
-        while (length >= SIZE_OF_LONG) {
-            long thisLong = getLongUnchecked(offset);
-            long thatLong = that.getLongUnchecked(offset);
-
-            if (thisLong != thatLong) {
-                return false;
-            }
-
-            offset += SIZE_OF_LONG;
-            length -= SIZE_OF_LONG;
-        }
-
-        while (length > 0) {
-            byte thisByte = getByteUnchecked(offset);
-            byte thatByte = that.getByteUnchecked(offset);
-            if (thisByte != thatByte) {
-                return false;
-            }
-            offset++;
-            length--;
-        }
-
-        return true;
+        return equalsUnchecked(0, that, 0, length());
     }
 
     /**
@@ -1024,6 +1000,10 @@ public final class Slice
             return false;
         }
 
+        if ((this == that) && (offset == otherOffset)) {
+            return true;
+        }
+
         checkIndexLength(offset, length);
         that.checkIndexLength(otherOffset, otherLength);
 
@@ -1032,10 +1012,6 @@ public final class Slice
 
     boolean equalsUnchecked(int offset, Slice that, int otherOffset, int length)
     {
-        if ((this == that) && (offset == otherOffset)) {
-            return true;
-        }
-
         long thisAddress = address + offset;
         long thatAddress = that.address + otherOffset;
 

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -1036,27 +1036,30 @@ public final class Slice
             return true;
         }
 
+        long thisAddress = address + offset;
+        long thatAddress = that.address + otherOffset;
+
         while (length >= SIZE_OF_LONG) {
-            long thisLong = getLongUnchecked(offset);
-            long thatLong = that.getLongUnchecked(otherOffset);
+            long thisLong = unsafe.getLong(base, thisAddress);
+            long thatLong = unsafe.getLong(that.base, thatAddress);
 
             if (thisLong != thatLong) {
                 return false;
             }
 
-            offset += SIZE_OF_LONG;
-            otherOffset += SIZE_OF_LONG;
+            thisAddress += SIZE_OF_LONG;
+            thatAddress += SIZE_OF_LONG;
             length -= SIZE_OF_LONG;
         }
 
         while (length > 0) {
-            byte thisByte = getByteUnchecked(offset);
-            byte thatByte = that.getByteUnchecked(otherOffset);
+            byte thisByte = unsafe.getByte(base, thisAddress);
+            byte thatByte = unsafe.getByte(that.base, thatAddress);
             if (thisByte != thatByte) {
                 return false;
             }
-            offset++;
-            otherOffset++;
+            thisAddress++;
+            thatAddress++;
             length--;
         }
 

--- a/src/test/java/io/airlift/slice/BenchmarkSlice.java
+++ b/src/test/java/io/airlift/slice/BenchmarkSlice.java
@@ -17,6 +17,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
@@ -35,6 +36,9 @@ import java.util.concurrent.TimeUnit;
 @SuppressWarnings("MethodMayBeStatic")
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Mode.AverageTime)
+@Fork(5)
+@Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 public class BenchmarkSlice
 {
     @Benchmark
@@ -44,11 +48,18 @@ public class BenchmarkSlice
         return data.slice1.compareTo(0, data.slice1.length(), data.slice2, 0, data.slice2.length());
     }
 
+    @Benchmark
+    public Object equalsUnchecked(BenchmarkData data)
+            throws Throwable
+    {
+        return data.slice1.equalsUnchecked(0, data.slice2, 0, data.slice1.length());
+    }
+
     @State(Scope.Thread)
     public static class BenchmarkData
     {
         @Param({"1", "7", "8", "16", "32", "64", "127", "32779"})
-        private int size;
+        private int size = 1;
 
         private Slice slice1;
         private Slice slice2;

--- a/src/test/java/io/airlift/slice/BenchmarkSlice.java
+++ b/src/test/java/io/airlift/slice/BenchmarkSlice.java
@@ -55,6 +55,13 @@ public class BenchmarkSlice
         return data.slice1.equalsUnchecked(0, data.slice2, 0, data.slice1.length());
     }
 
+    @Benchmark
+    public Object equalsObject(BenchmarkData data)
+            throws Throwable
+    {
+        return data.slice1.equals(data.slice2);
+    }
+
     @State(Scope.Thread)
     public static class BenchmarkData
     {
@@ -85,7 +92,7 @@ public class BenchmarkSlice
         // assure the benchmarks are valid before running
         BenchmarkData data = new BenchmarkData();
         data.setup();
-        new BenchmarkSlice().compareTo(data);
+        new BenchmarkSlice().equalsObject(data);
 
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)


### PR DESCRIPTION
This PR improves performance of `equals `and `equalsUnchecked`. This is accomplished by using address directly with unsafe.

Before `equals`
```
Benchmark                       (size)  Mode  Cnt     Score   Error  Units
BenchmarkSlice.equalsUnchecked       1  avgt   50     4,694 ± 0,065  ns/op
BenchmarkSlice.equalsUnchecked       7  avgt   50    15,023 ± 0,088  ns/op
BenchmarkSlice.equalsUnchecked       8  avgt   50     4,857 ± 0,041  ns/op
BenchmarkSlice.equalsUnchecked      16  avgt   50     8,303 ± 0,060  ns/op
BenchmarkSlice.equalsUnchecked      32  avgt   50    11,382 ± 0,051  ns/op
BenchmarkSlice.equalsUnchecked      64  avgt   50    17,036 ± 0,513  ns/op
BenchmarkSlice.equalsUnchecked     127  avgt   50    36,838 ± 0,061  ns/op
BenchmarkSlice.equalsUnchecked   32779  avgt   50  5674,848 ± 6,782  ns/op
```

After equals
```
Benchmark                       (size)  Mode  Cnt     Score    Error  Units
BenchmarkSlice.equalsUnchecked       1  avgt   50     4,854 ±  0,055  ns/op
BenchmarkSlice.equalsUnchecked       7  avgt   50    11,554 ±  0,161  ns/op
BenchmarkSlice.equalsUnchecked       8  avgt   50     4,911 ±  0,060  ns/op
BenchmarkSlice.equalsUnchecked      16  avgt   50     6,143 ±  0,112  ns/op
BenchmarkSlice.equalsUnchecked      32  avgt   50     9,221 ±  0,112  ns/op
BenchmarkSlice.equalsUnchecked      64  avgt   50    14,365 ±  0,123  ns/op
BenchmarkSlice.equalsUnchecked     127  avgt   50    26,765 ±  0,191  ns/op
BenchmarkSlice.equalsUnchecked   32779  avgt   50  3844,702 ± 12,107  ns/op
```

Before `equalsObject`
```
Benchmark                    (size)  Mode  Cnt     Score   Error  Units
BenchmarkSlice.equalsObject       1  avgt   50     4,810 ± 0,035  ns/op
BenchmarkSlice.equalsObject       7  avgt   50    16,664 ± 0,079  ns/op
BenchmarkSlice.equalsObject       8  avgt   50     5,093 ± 0,075  ns/op
BenchmarkSlice.equalsObject      16  avgt   50     8,578 ± 0,045  ns/op
BenchmarkSlice.equalsObject      32  avgt   50    12,319 ± 0,072  ns/op
BenchmarkSlice.equalsObject      64  avgt   50    18,464 ± 0,052  ns/op
BenchmarkSlice.equalsObject     127  avgt   50    39,828 ± 0,056  ns/op
BenchmarkSlice.equalsObject   32779  avgt   50  6284,251 ± 3,951  ns/op
```

After `equalsObject`
```
Benchmark                    (size)  Mode  Cnt     Score    Error  Units
BenchmarkSlice.equalsObject       1  avgt   50     4,947 ±  0,189  ns/op
BenchmarkSlice.equalsObject       7  avgt   50    11,924 ±  0,114  ns/op
BenchmarkSlice.equalsObject       8  avgt   50     5,180 ±  0,064  ns/op
BenchmarkSlice.equalsObject      16  avgt   50     6,468 ±  0,112  ns/op
BenchmarkSlice.equalsObject      32  avgt   50     9,759 ±  0,075  ns/op
BenchmarkSlice.equalsObject      64  avgt   50    13,810 ±  0,070  ns/op
BenchmarkSlice.equalsObject     127  avgt   50    27,591 ±  0,059  ns/op
BenchmarkSlice.equalsObject   32779  avgt   50  3829,908 ± 10,580  ns/op
```
