### PR TITLE
Introduce getters for uint_{16,32} types

### DIFF
--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -380,6 +380,18 @@ public final class Slice
     }
 
     /**
+     * Gets an unsigned 16-bit short integer at the specified absolute {@code index}
+     * in this slice.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0} or
+     * {@code index + 2} is greater than {@code this.length()}
+     */
+    public int getUnsignedShort(int index)
+    {
+        return getShort(index) & 0xFFFF;
+    }
+
+    /**
      * Gets a 32-bit integer at the specified absolute {@code index} in
      * this buffer.
      *
@@ -395,6 +407,18 @@ public final class Slice
     int getIntUnchecked(int index)
     {
         return unsafe.getInt(base, address + index);
+    }
+
+    /**
+     * Gets an unsigned 32-bit integer at the specified absolute {@code index} in
+     * this buffer.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0} or
+     * {@code index + 4} is greater than {@code this.length()}
+     */
+    public long getUnsignedInt(int index)
+    {
+        return getInt(index) & 0xFFFFFFFFL;
     }
 
     /**

--- a/src/test/java/io/airlift/slice/TestUnsignedGetters.java
+++ b/src/test/java/io/airlift/slice/TestUnsignedGetters.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class TestUnsignedGetters
+{
+    Slice slice;
+
+    @BeforeTest
+    public void fillTestData()
+    {
+        slice = allocate(8);
+        slice.fill((byte)0xA5);
+    }
+
+    @Test
+    public void testUnsignedByte()
+    {
+        int expected = 0xA5;
+        assertTrue(expected > 0);
+        assertEquals(slice.getUnsignedByte(0), expected);
+    }
+
+    @Test
+    public void testUnsignedShort()
+    {
+        int expected = 0xA5A5;
+        assertTrue(expected > 0);
+        assertEquals(slice.getUnsignedShort(0), expected);
+    }
+
+    @Test
+    public void testUnsignedInt()
+    {
+        long expected = 0xA5A5A5A5L;
+        assertTrue(expected > 0);  // make sure we didn't forget the L in the constant above
+        assertEquals(slice.getUnsignedInt(0), expected);
+    }
+
+    protected Slice allocate(int size)
+    {
+        return Slices.allocate(size);
+    }
+}


### PR DESCRIPTION
Useful for picking apart C structs from mapped files