### PR TITLE
Add support for uint64_t that throws if > LONG_MAX

### DIFF
--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -440,6 +440,25 @@ public final class Slice
     }
 
     /**
+     * Gets an unsigned 64-bit long integer at the specified absolute {@code index} in
+     * this buffer.  Since Java does not have a primitive type that can fit unsigned long
+     * values, instead we throw -- this is useful for interoperating with unsigned values
+     * that almost always fit into 63 bits just fine, but you'd rather fail fast if it doesn't.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0} or
+     * {@code index + 8} is greater than {@code this.length()}
+     * @throws IllegalStateException if the unsigned long cannot fit into a signed Java long
+     */
+    public long getUnsignedLongOrThrow(int index)
+    {
+        long result = getLong(index);
+        if (result < 0) {
+            throw new IllegalStateException("Unsigned long too big to fit in primitive type");
+        }
+        return result;
+    }
+
+    /**
      * Gets a 32-bit float at the specified absolute {@code index} in
      * this buffer.
      *

--- a/src/test/java/io/airlift/slice/TestUnsignedGetters.java
+++ b/src/test/java/io/airlift/slice/TestUnsignedGetters.java
@@ -54,6 +54,12 @@ public class TestUnsignedGetters
         assertEquals(slice.getUnsignedInt(0), expected);
     }
 
+    @Test(expectedExceptions=IllegalStateException.class)
+    public void testUnsignedLong()
+    {
+        slice.getUnsignedLongOrThrow(0);
+    }
+
     protected Slice allocate(int size)
     {
         return Slices.allocate(size);


### PR DESCRIPTION
For discussion, obviously this behavior is not always great.
