### PR TITLE
Remove recently added final from OutputStreamSliceOutput

### DIFF
--- a/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
+++ b/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
@@ -27,7 +27,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 
-public final class OutputStreamSliceOutput
+public class OutputStreamSliceOutput
         extends SliceOutput
 {
     private static final int DEFAULT_BUFFER_SIZE = 4 * 1024;


### PR DESCRIPTION
SliceOutput is a class because it extends from OutputStream which is a class.
Additionally, SliceOutput has final methods for common so delegation does
not work.  The recent addition of final to this class makes reuse impossible.