### PR TITLE
Update getRetainedSize methods in Slice and SliceOutput to return long

### DIFF
--- a/src/main/java/io/airlift/slice/BasicSliceOutput.java
+++ b/src/main/java/io/airlift/slice/BasicSliceOutput.java
@@ -62,7 +62,7 @@ public class BasicSliceOutput
     }
 
     @Override
-    public int getRetainedSize()
+    public long getRetainedSize()
     {
         return slice.getRetainedSize() + INSTANCE_SIZE;
     }

--- a/src/main/java/io/airlift/slice/DynamicSliceOutput.java
+++ b/src/main/java/io/airlift/slice/DynamicSliceOutput.java
@@ -61,7 +61,7 @@ public class DynamicSliceOutput
     }
 
     @Override
-    public int getRetainedSize()
+    public long getRetainedSize()
     {
         return slice.getRetainedSize() + INSTANCE_SIZE;
     }

--- a/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
+++ b/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
@@ -102,7 +102,7 @@ public class OutputStreamSliceOutput
     }
 
     @Override
-    public int getRetainedSize()
+    public long getRetainedSize()
     {
         return slice.getRetainedSize() + INSTANCE_SIZE;
     }

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -37,7 +37,6 @@ import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.StringDecoder.decodeString;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -94,7 +93,7 @@ public final class Slice
     /**
      * Bytes retained by the slice
      */
-    private final int retainedSize;
+    private final long retainedSize;
 
     /**
      * Reference is typically a ByteBuffer object, but can be any object this
@@ -126,7 +125,7 @@ public final class Slice
         this.base = base;
         this.address = ARRAY_BYTE_BASE_OFFSET;
         this.size = base.length;
-        this.retainedSize = INSTANCE_SIZE + toIntExact(sizeOf(base));
+        this.retainedSize = INSTANCE_SIZE + sizeOf(base);
         this.reference = null;
     }
 
@@ -144,7 +143,7 @@ public final class Slice
         this.base = base;
         this.address = ARRAY_BYTE_BASE_OFFSET + offset;
         this.size = length;
-        this.retainedSize = INSTANCE_SIZE + toIntExact(sizeOf(base));
+        this.retainedSize = INSTANCE_SIZE + sizeOf(base);
         this.reference = null;
     }
 
@@ -162,7 +161,7 @@ public final class Slice
         this.base = base;
         this.address = ARRAY_BOOLEAN_BASE_OFFSET + offset * ARRAY_BOOLEAN_INDEX_SCALE;
         this.size = length * ARRAY_BOOLEAN_INDEX_SCALE;
-        this.retainedSize = INSTANCE_SIZE + toIntExact(sizeOf(base));
+        this.retainedSize = INSTANCE_SIZE + sizeOf(base);
         this.reference = null;
     }
 
@@ -180,7 +179,7 @@ public final class Slice
         this.base = base;
         this.address = ARRAY_SHORT_BASE_OFFSET + offset * ARRAY_SHORT_INDEX_SCALE;
         this.size = length * ARRAY_SHORT_INDEX_SCALE;
-        this.retainedSize = INSTANCE_SIZE + toIntExact(sizeOf(base));
+        this.retainedSize = INSTANCE_SIZE + sizeOf(base);
         this.reference = null;
     }
 
@@ -198,7 +197,7 @@ public final class Slice
         this.base = base;
         this.address = ARRAY_INT_BASE_OFFSET + offset * ARRAY_INT_INDEX_SCALE;
         this.size = length * ARRAY_INT_INDEX_SCALE;
-        this.retainedSize = INSTANCE_SIZE + toIntExact(sizeOf(base));
+        this.retainedSize = INSTANCE_SIZE + sizeOf(base);
         this.reference = null;
     }
 
@@ -216,7 +215,7 @@ public final class Slice
         this.base = base;
         this.address = ARRAY_LONG_BASE_OFFSET + offset * ARRAY_LONG_INDEX_SCALE;
         this.size = length * ARRAY_LONG_INDEX_SCALE;
-        this.retainedSize = INSTANCE_SIZE + toIntExact(sizeOf(base));
+        this.retainedSize = INSTANCE_SIZE + sizeOf(base);
         this.reference = null;
     }
 
@@ -234,7 +233,7 @@ public final class Slice
         this.base = base;
         this.address = ARRAY_FLOAT_BASE_OFFSET + offset * ARRAY_FLOAT_INDEX_SCALE;
         this.size = length * ARRAY_FLOAT_INDEX_SCALE;
-        this.retainedSize = INSTANCE_SIZE + toIntExact(sizeOf(base));
+        this.retainedSize = INSTANCE_SIZE + sizeOf(base);
         this.reference = null;
     }
 
@@ -252,14 +251,14 @@ public final class Slice
         this.base = base;
         this.address = ARRAY_DOUBLE_BASE_OFFSET + offset * ARRAY_DOUBLE_INDEX_SCALE;
         this.size = length * ARRAY_DOUBLE_INDEX_SCALE;
-        this.retainedSize = INSTANCE_SIZE + toIntExact(sizeOf(base));
+        this.retainedSize = INSTANCE_SIZE + sizeOf(base);
         this.reference = null;
     }
 
     /**
      * Creates a slice for directly accessing the base object.
      */
-    Slice(@Nullable Object base, long address, int size, int retainedSize, @Nullable Object reference)
+    Slice(@Nullable Object base, long address, int size, long retainedSize, @Nullable Object reference)
     {
         if (address <= 0) {
             throw new IllegalArgumentException(format("Invalid address: %s", address));
@@ -306,7 +305,7 @@ public final class Slice
     /**
      * Approximate number of bytes retained by this slice.
      */
-    public int getRetainedSize()
+    public long getRetainedSize()
     {
         return retainedSize;
     }

--- a/src/main/java/io/airlift/slice/SliceOutput.java
+++ b/src/main/java/io/airlift/slice/SliceOutput.java
@@ -42,7 +42,7 @@ public abstract class SliceOutput
     /**
      * Approximate number of bytes retained by this.
      */
-    public abstract int getRetainedSize();
+    public abstract long getRetainedSize();
 
     /**
      * Returns the number of writable bytes which is equal to

--- a/src/test/java/io/airlift/slice/TestSliceOutput.java
+++ b/src/test/java/io/airlift/slice/TestSliceOutput.java
@@ -88,7 +88,7 @@ public class TestSliceOutput
         int sliceOutputInstanceSize = ClassLayout.parseClass(DynamicSliceOutput.class).instanceSize();
         DynamicSliceOutput output = new DynamicSliceOutput(10);
 
-        int originalRetainedSize = output.getRetainedSize();
+        long originalRetainedSize = output.getRetainedSize();
         assertEquals(originalRetainedSize, sliceOutputInstanceSize + output.getUnderlyingSlice().getRetainedSize());
         assertEquals(output.size(), 0);
         output.appendLong(0);


### PR DESCRIPTION
It will be less error-prone if the `Slice` retained sizes are `long` instead of `int` (with `int` we need to be careful as `int` overflows can sneak in). We have already updated `Block` to use `long` for size-related calculations to get rid of this problem.
