### PR TITLE
Add compact flag into Slice

### DIFF
--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -99,21 +99,21 @@ public final class Slice
     private final long retainedSize;
 
     /**
-     * Reference have two use cases:
-     *
+     * Reference has two use cases:
+     * <p>
      * 1. It can be an object this slice must hold onto to assure that the
      * underlying memory is not freed by the garbage collector.
      * It is typically a ByteBuffer object, but can be any object.
-     *
-     * 2. If reference is not used to prevent garbage collector to free
-     * underlying memory, it will be used as the flag to indicate whether
-     * the slice is compact.
-     * When reference == COMPACT, the slice is considered as compact.
+     * This is not needed for arrays, since the array is referenced by {@code base}.
+     * <p>
+     * 2. If reference is not used to prevent garbage collector from freeing the
+     * underlying memory, it will be used to indicate if the slice is compact.
+     * When {@code reference == COMPACT}, the slice is considered as compact.
      * Otherwise, it will be null.
-     *
+     * <p>
      * A slice is considered compact if the base object is an heap array and
      * it contains the whole array.
-     * Thus for the first use case, the slice is always considered as not compact.
+     * Thus, for the first use case, the slice is always considered as not compact.
      */
     private final Object reference;
 
@@ -159,7 +159,7 @@ public final class Slice
         this.address = ARRAY_BYTE_BASE_OFFSET + offset;
         this.size = length;
         this.retainedSize = INSTANCE_SIZE + sizeOf(base);
-        this.reference = (offset == 0 && length == base.length ? COMPACT : NOT_COMPACT);
+        this.reference = (offset == 0 && length == base.length) ? COMPACT : NOT_COMPACT;
     }
 
     /**
@@ -842,9 +842,7 @@ public final class Slice
         if (reference == COMPACT) {
             return new Slice(base, address + index, length, retainedSize, NOT_COMPACT);
         }
-        else {
-            return new Slice(base, address + index, length, retainedSize, reference);
-        }
+        return new Slice(base, address + index, length, retainedSize, reference);
     }
 
     public int indexOfByte(int b)

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -59,6 +59,8 @@ public final class Slice
         implements Comparable<Slice>
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(Slice.class).instanceSize();
+    private static final Object COMPACT = new byte[0];
+    private static final Object NOT_COMPACT = null;
 
     /**
      * @deprecated use {@link Slices#wrappedBuffer(java.nio.ByteBuffer)}
@@ -97,9 +99,21 @@ public final class Slice
     private final long retainedSize;
 
     /**
-     * Reference is typically a ByteBuffer object, but can be any object this
-     * slice must hold onto to assure that the underlying memory is not
-     * freed by the garbage collector.
+     * Reference have two use cases:
+     *
+     * 1. It can be an object this slice must hold onto to assure that the
+     * underlying memory is not freed by the garbage collector.
+     * It is typically a ByteBuffer object, but can be any object.
+     *
+     * 2. If reference is not used to prevent garbage collector to free
+     * underlying memory, it will be used as the flag to indicate whether
+     * the slice is compact.
+     * When reference == COMPACT, the slice is considered as compact.
+     * Otherwise, it will be null.
+     *
+     * A slice is considered compact if the base object is an heap array and
+     * it contains the whole array.
+     * Thus for the first use case, the slice is always considered as not compact.
      */
     private final Object reference;
 
@@ -114,7 +128,7 @@ public final class Slice
         this.address = 0;
         this.size = 0;
         this.retainedSize = INSTANCE_SIZE;
-        this.reference = null;
+        this.reference = COMPACT;
     }
 
     /**
@@ -127,7 +141,7 @@ public final class Slice
         this.address = ARRAY_BYTE_BASE_OFFSET;
         this.size = base.length;
         this.retainedSize = INSTANCE_SIZE + sizeOf(base);
-        this.reference = null;
+        this.reference = COMPACT;
     }
 
     /**
@@ -145,7 +159,7 @@ public final class Slice
         this.address = ARRAY_BYTE_BASE_OFFSET + offset;
         this.size = length;
         this.retainedSize = INSTANCE_SIZE + sizeOf(base);
-        this.reference = null;
+        this.reference = (offset == 0 && length == base.length ? COMPACT : NOT_COMPACT);
     }
 
     /**
@@ -163,7 +177,7 @@ public final class Slice
         this.address = sizeOfBooleanArray(offset);
         this.size = multiplyExact(length, ARRAY_BOOLEAN_INDEX_SCALE);
         this.retainedSize = INSTANCE_SIZE + sizeOf(base);
-        this.reference = null;
+        this.reference = (offset == 0 && length == base.length) ? COMPACT : NOT_COMPACT;
     }
 
     /**
@@ -181,7 +195,7 @@ public final class Slice
         this.address = sizeOfShortArray(offset);
         this.size = multiplyExact(length, ARRAY_SHORT_INDEX_SCALE);
         this.retainedSize = INSTANCE_SIZE + sizeOf(base);
-        this.reference = null;
+        this.reference = (offset == 0 && length == base.length) ? COMPACT : NOT_COMPACT;
     }
 
     /**
@@ -199,7 +213,7 @@ public final class Slice
         this.address = sizeOfIntArray(offset);
         this.size = multiplyExact(length, ARRAY_INT_INDEX_SCALE);
         this.retainedSize = INSTANCE_SIZE + sizeOf(base);
-        this.reference = null;
+        this.reference = (offset == 0 && length == base.length) ? COMPACT : NOT_COMPACT;
     }
 
     /**
@@ -217,7 +231,7 @@ public final class Slice
         this.address = sizeOfLongArray(offset);
         this.size = multiplyExact(length, ARRAY_LONG_INDEX_SCALE);
         this.retainedSize = INSTANCE_SIZE + sizeOf(base);
-        this.reference = null;
+        this.reference = (offset == 0 && length == base.length) ? COMPACT : NOT_COMPACT;
     }
 
     /**
@@ -235,7 +249,7 @@ public final class Slice
         this.address = sizeOfFloatArray(offset);
         this.size = multiplyExact(length, ARRAY_FLOAT_INDEX_SCALE);
         this.retainedSize = INSTANCE_SIZE + sizeOf(base);
-        this.reference = null;
+        this.reference = (offset == 0 && length == base.length) ? COMPACT : NOT_COMPACT;
     }
 
     /**
@@ -253,7 +267,7 @@ public final class Slice
         this.address = sizeOfDoubleArray(offset);
         this.size = multiplyExact(length, ARRAY_DOUBLE_INDEX_SCALE);
         this.retainedSize = INSTANCE_SIZE + sizeOf(base);
-        this.reference = null;
+        this.reference = (offset == 0 && length == base.length) ? COMPACT : NOT_COMPACT;
     }
 
     /**
@@ -309,6 +323,15 @@ public final class Slice
     public long getRetainedSize()
     {
         return retainedSize;
+    }
+
+    /**
+     * A slice is considered compact if the base object is an array and it contains the whole array.
+     * As a result, it cannot be a view of a bigger slice.
+     */
+    public boolean isCompact()
+    {
+        return reference == COMPACT;
     }
 
     /**
@@ -815,7 +838,13 @@ public final class Slice
         if (length == 0) {
             return Slices.EMPTY_SLICE;
         }
-        return new Slice(base, address + index, length, retainedSize, reference);
+
+        if (reference == COMPACT) {
+            return new Slice(base, address + index, length, retainedSize, NOT_COMPACT);
+        }
+        else {
+            return new Slice(base, address + index, length, retainedSize, reference);
+        }
     }
 
     public int indexOfByte(int b)

--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -28,7 +28,6 @@ import static io.airlift.slice.Preconditions.checkArgument;
 import static io.airlift.slice.Preconditions.checkPositionIndexes;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
-import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public final class Slices
 {
@@ -120,8 +119,7 @@ public final class Slices
         }
 
         if (buffer.hasArray()) {
-            int address = ARRAY_BYTE_BASE_OFFSET + buffer.arrayOffset() + buffer.position();
-            return new Slice(buffer.array(), address, buffer.limit() - buffer.position(), buffer.array().length, null);
+            return new Slice(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.limit() - buffer.position());
         }
 
         throw new IllegalArgumentException("cannot wrap " + buffer.getClass().getName());

--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -115,11 +115,11 @@ public final class Slices
     {
         if (buffer.isDirect()) {
             long address = getAddress(buffer);
-            return new Slice(null, address + buffer.position(), buffer.limit() - buffer.position(), buffer.capacity(), buffer);
+            return new Slice(null, address + buffer.position(), buffer.remaining(), buffer.capacity(), buffer);
         }
 
         if (buffer.hasArray()) {
-            return new Slice(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.limit() - buffer.position());
+            return new Slice(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
         }
 
         throw new IllegalArgumentException("cannot wrap " + buffer.getClass().getName());

--- a/src/test/java/io/airlift/slice/TestSliceCompactFlag.java
+++ b/src/test/java/io/airlift/slice/TestSliceCompactFlag.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.slice;
+
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestSliceCompactFlag
+{
+    @Test
+    public void testSliceConstructors()
+            throws Exception
+    {
+        assertCompact(new Slice());
+
+        boolean[] booleanArray = {true, false, false, true, false, true};
+        assertCompact(new Slice(booleanArray, 0, booleanArray.length));
+        assertNotCompact(new Slice(booleanArray, 0, booleanArray.length - 1));
+        assertNotCompact(new Slice(booleanArray, 1, booleanArray.length - 1));
+
+        byte[] byteArray = {(byte) 0, (byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5};
+        assertCompact(new Slice(byteArray));
+        assertCompact(new Slice(byteArray, 0, byteArray.length));
+        assertNotCompact(new Slice(byteArray, 0, byteArray.length - 1));
+        assertNotCompact(new Slice(byteArray, 1, byteArray.length - 1));
+
+        short[] shortArray = {(short) 0, (short) 1, (short) 2, (short) 3, (short) 4, (short) 5};
+        assertCompact(new Slice(shortArray, 0, shortArray.length));
+        assertNotCompact(new Slice(shortArray, 0, shortArray.length - 1));
+        assertNotCompact(new Slice(shortArray, 1, shortArray.length - 1));
+
+        int[] intArray = {0, 1, 2, 3, 4, 5};
+        assertCompact(new Slice(intArray, 0, intArray.length));
+        assertNotCompact(new Slice(intArray, 0, intArray.length - 1));
+        assertNotCompact(new Slice(intArray, 1, intArray.length - 1));
+
+        long[] longArray = {0L, 1L, 2L, 3L, 4L, 5L};
+        assertCompact(new Slice(longArray, 0, longArray.length));
+        assertNotCompact(new Slice(longArray, 0, longArray.length - 1));
+        assertNotCompact(new Slice(longArray, 1, longArray.length - 1));
+
+        float[] floatArray = {0f, 1f, 2f, 3f, 4f, 5f};
+        assertCompact(new Slice(floatArray, 0, floatArray.length));
+        assertNotCompact(new Slice(floatArray, 0, floatArray.length - 1));
+        assertNotCompact(new Slice(floatArray, 1, floatArray.length - 1));
+
+        double[] doubleArray = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0};
+        assertCompact(new Slice(doubleArray, 0, doubleArray.length));
+        assertNotCompact(new Slice(doubleArray, 0, doubleArray.length - 1));
+        assertNotCompact(new Slice(doubleArray, 1, doubleArray.length - 1));
+    }
+
+    @Test
+    public void testSubSliceAndCopy()
+    {
+        byte[] byteArray = {(byte) 0, (byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5};
+        Slice slice = new Slice(byteArray);
+        assertCompact(slice.slice(0, slice.length()));
+        assertCompact(Slices.copyOf(slice));
+        assertCompact(Slices.copyOf(slice, 0, slice.length() - 1));
+        assertCompact(Slices.copyOf(slice, 1, slice.length() - 1));
+
+        Slice subSlice1 = slice.slice(0, slice.length() - 1);
+        Slice subSlice2 = slice.slice(1, slice.length() - 1);
+        assertNotCompact(subSlice1);
+        assertNotCompact(subSlice2);
+        assertCompact(Slices.copyOf(subSlice1));
+        assertCompact(Slices.copyOf(subSlice2));
+    }
+
+    @Test
+    public void testWrapDirectBuffer()
+            throws Exception
+    {
+        /**
+         * For DirectByteBuffer, the slice is always considered as not compacted
+         * because there is no easy way to tell whether the DirectByteBuffer itself
+         * is a slice of consecutive native memory.
+         */
+        ByteBuffer buffer = ByteBuffer.allocateDirect(50);
+
+        // initialize buffer
+        for (int i = 0; i < 50; i++) {
+            buffer.put((byte) i);
+        }
+
+        // test full buffer
+        buffer.rewind();
+        Slice slice = Slices.wrappedBuffer(buffer);
+        assertNotCompact(slice);
+
+        // test limited buffer
+        buffer.position(10).limit(30);
+        slice = Slices.wrappedBuffer(buffer);
+        assertNotCompact(slice);
+
+        // test limited buffer after slicing
+        buffer = buffer.slice();
+        slice = Slices.wrappedBuffer(buffer);
+        assertNotCompact(slice);
+    }
+
+    @Test
+    public void testWrapHeapBuffer()
+            throws Exception
+    {
+        ByteBuffer buffer = ByteBuffer.allocate(50);
+
+        // initialize buffer
+        for (int i = 0; i < 50; i++) {
+            buffer.put((byte) i);
+        }
+
+        // test full buffer
+        buffer.rewind();
+        Slice slice = Slices.wrappedBuffer(buffer);
+        assertCompact(slice);
+
+        // test limited buffer
+        buffer.position(10).limit(30);
+        slice = Slices.wrappedBuffer(buffer);
+        assertNotCompact(slice);
+
+        // test limited buffer after slicing
+        buffer = buffer.slice();
+        slice = Slices.wrappedBuffer(buffer);
+        assertNotCompact(slice);
+    }
+
+    private static void assertCompact(Slice data)
+    {
+        assertTrue(data.isCompact());
+    }
+
+    private static void assertNotCompact(Slice data)
+    {
+        assertFalse(data.isCompact());
+    }
+}

--- a/src/test/java/io/airlift/slice/TestSliceCompactFlag.java
+++ b/src/test/java/io/airlift/slice/TestSliceCompactFlag.java
@@ -17,8 +17,9 @@ import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 public class TestSliceCompactFlag
@@ -71,8 +72,13 @@ public class TestSliceCompactFlag
     {
         byte[] byteArray = {(byte) 0, (byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5};
         Slice slice = new Slice(byteArray);
+
+        assertCompact(slice);
         assertCompact(slice.slice(0, slice.length()));
+        assertSame(slice.slice(0, slice.length()), slice);
+
         assertCompact(Slices.copyOf(slice));
+        assertNotSame(Slices.copyOf(slice).getBase(), slice.getBase());
         assertCompact(Slices.copyOf(slice, 0, slice.length() - 1));
         assertCompact(Slices.copyOf(slice, 1, slice.length() - 1));
 
@@ -88,11 +94,9 @@ public class TestSliceCompactFlag
     public void testWrapDirectBuffer()
             throws Exception
     {
-        /**
-         * For DirectByteBuffer, the slice is always considered as not compacted
-         * because there is no easy way to tell whether the DirectByteBuffer itself
-         * is a slice of consecutive native memory.
-         */
+        // For DirectByteBuffer, the slice is always considered as not compacted
+        // because there is no easy way to tell whether the DirectByteBuffer itself
+        // is a view over a larger allocation.
         ByteBuffer buffer = ByteBuffer.allocateDirect(50);
 
         // initialize buffer

--- a/src/test/java/io/airlift/slice/TestSlices.java
+++ b/src/test/java/io/airlift/slice/TestSlices.java
@@ -13,6 +13,7 @@
  */
 package io.airlift.slice;
 
+import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
@@ -23,6 +24,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.Slices.wrappedBooleanArray;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.airlift.slice.Slices.wrappedDoubleArray;
@@ -46,6 +48,14 @@ public class TestSlices
             throws Exception
     {
         testWrapping(ByteBuffer.allocate(50));
+    }
+
+    @Test
+    public void testWrapHeapBufferRetainedSize()
+    {
+        ByteBuffer heapByteBuffer = ByteBuffer.allocate(50);
+        Slice slice = Slices.wrappedBuffer(heapByteBuffer);
+        assertEquals(slice.getRetainedSize(), ClassLayout.parseClass(Slice.class).instanceSize() + sizeOf(heapByteBuffer.array()));
     }
 
     private static void testWrapping(ByteBuffer buffer)


### PR DESCRIPTION
This will help application to know whether the Slice is a view of a bigger slices, and thus decide whether memory can be saved by "compacting" a slice (via `Slices.copyOf`). 