### PR TITLE
Make sure to close the output stream

### DIFF
--- a/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
+++ b/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
@@ -79,8 +79,12 @@ public class OutputStreamSliceOutput
     public void close()
             throws IOException
     {
-        flushBufferToOutputStream();
-        outputStream.close();
+        try{
+            flushBufferToOutputStream();
+        }
+        finally {
+            outputStream.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
Otherwise we leak resources. @martint @dain can you please take a look?