### PR TITLE
add interface for reference object of the slice

### DIFF
--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -310,7 +310,15 @@ public final class Slice
     {
         return retainedSize;
     }
-
+    
+    /**
+     * Return the reference object
+     */
+     public Object getReference() 
+     {
+         return reference;
+     }
+     
     /**
      * Fill the slice with the specified value;
      */


### PR DESCRIPTION
Add interface for reference object of the slice,  to check if the slice use off-heap or heap memory. And also we can use reference (cast to bytebuffer) to free off-heap memory.