### PR TITLE
Add getRetainedSize method to SliceInput

### DIFF
--- a/src/main/java/io/airlift/slice/BasicSliceInput.java
+++ b/src/main/java/io/airlift/slice/BasicSliceInput.java
@@ -13,6 +13,8 @@
  */
 package io.airlift.slice;
 
+import org.openjdk.jol.info.ClassLayout;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
@@ -28,6 +30,8 @@ import static java.util.Objects.requireNonNull;
 public final class BasicSliceInput
         extends FixedLengthSliceInput
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(BasicSliceInput.class).instanceSize();
+
     private final Slice slice;
     private int position;
 
@@ -208,6 +212,12 @@ public final class BasicSliceInput
         length = Math.min(length, available());
         position += length;
         return length;
+    }
+
+    @Override
+    public long getRetainedSize()
+    {
+        return INSTANCE_SIZE + slice.getRetainedSize();
     }
 
     /**

--- a/src/main/java/io/airlift/slice/ChunkedSliceInput.java
+++ b/src/main/java/io/airlift/slice/ChunkedSliceInput.java
@@ -13,6 +13,8 @@
  */
 package io.airlift.slice;
 
+import org.openjdk.jol.info.ClassLayout;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -30,6 +32,8 @@ import static java.util.Objects.requireNonNull;
 public final class ChunkedSliceInput
         extends FixedLengthSliceInput
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ChunkedSliceInput.class).instanceSize();
+
     private final InternalLoader<?> loader;
     private final Slice buffer;
 
@@ -312,6 +316,12 @@ public final class ChunkedSliceInput
     }
 
     @Override
+    public long getRetainedSize()
+    {
+        return INSTANCE_SIZE + loader.getRetainedSize() + buffer.getRetainedSize();
+    }
+
+    @Override
     public String toString()
     {
         StringBuilder builder = new StringBuilder("SliceStreamInput{");
@@ -350,6 +360,8 @@ public final class ChunkedSliceInput
 
     private static class InternalLoader<T extends BufferReference>
     {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(InternalLoader.class).instanceSize();
+
         private final SliceLoader<T> loader;
         private final T bufferReference;
 
@@ -369,6 +381,11 @@ public final class ChunkedSliceInput
         public void load(long position, int length)
         {
             loader.load(position, bufferReference, length);
+        }
+
+        public long getRetainedSize()
+        {
+            return INSTANCE_SIZE;
         }
 
         public void close()

--- a/src/main/java/io/airlift/slice/InputStreamSliceInput.java
+++ b/src/main/java/io/airlift/slice/InputStreamSliceInput.java
@@ -13,6 +13,8 @@
  */
 package io.airlift.slice;
 
+import org.openjdk.jol.info.ClassLayout;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -24,10 +26,12 @@ import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
+import static io.airlift.slice.SizeOf.sizeOf;
 
 public final class InputStreamSliceInput
         extends SliceInput
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(InputStreamSliceInput.class).instanceSize();
     private static final int DEFAULT_BUFFER_SIZE = 4 * 1024;
     private static final int MINIMUM_CHUNK_SIZE = 1024;
 
@@ -280,6 +284,12 @@ public final class InputStreamSliceInput
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @Override
+    public long getRetainedSize()
+    {
+        return INSTANCE_SIZE + sizeOf(buffer);
     }
 
     private int availableBytes()

--- a/src/main/java/io/airlift/slice/SliceInput.java
+++ b/src/main/java/io/airlift/slice/SliceInput.java
@@ -273,6 +273,11 @@ public abstract class SliceInput
     {
     }
 
+    /**
+     * Approximate number of bytes retained by this instance.
+     */
+    public abstract long getRetainedSize();
+
     //
     // Unsupported operations
     //

--- a/src/test/java/io/airlift/slice/TestBasicSliceInput.java
+++ b/src/test/java/io/airlift/slice/TestBasicSliceInput.java
@@ -13,6 +13,11 @@
  */
 package io.airlift.slice;
 
+import org.openjdk.jol.info.ClassLayout;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
 public class TestBasicSliceInput
         extends AbstractSliceInputTest
 {
@@ -20,5 +25,13 @@ public class TestBasicSliceInput
     protected SliceInput createSliceInput(Slice slice)
     {
         return new BasicSliceInput(slice);
+    }
+
+    @Test
+    public void testRetainedSize()
+    {
+        Slice slice = Slices.allocate(1024);
+        SliceInput input = new BasicSliceInput(slice);
+        assertEquals(input.getRetainedSize(), ClassLayout.parseClass(BasicSliceInput.class).instanceSize() + slice.getRetainedSize());
     }
 }

--- a/src/test/java/io/airlift/slice/TestChunkedSliceInput.java
+++ b/src/test/java/io/airlift/slice/TestChunkedSliceInput.java
@@ -16,8 +16,11 @@ package io.airlift.slice;
 import com.google.common.base.Strings;
 import io.airlift.slice.ChunkedSliceInput.BufferReference;
 import io.airlift.slice.ChunkedSliceInput.SliceLoader;
+import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,6 +29,7 @@ import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkPositionIndex;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestChunkedSliceInput
         extends AbstractSliceInputTest
@@ -113,5 +117,50 @@ public class TestChunkedSliceInput
                 .boxed()
                 .collect(Collectors.toList());
         assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testRetainedSize()
+    {
+        int length = 1024;
+        int bufferSize = 128;
+        Slice slice = Slices.utf8Slice(Strings.repeat("0", length));
+        SliceSliceLoader loader = new SliceSliceLoader(slice);
+        ChunkedSliceInput chunkedSliceInput = new ChunkedSliceInput(loader, bufferSize);
+
+        for (int i = 0; i < length; i++) {
+            chunkedSliceInput.setPosition(i);
+            chunkedSliceInput.readByte();
+            assertRetainedSize(chunkedSliceInput);
+            long retainedSize = chunkedSliceInput.getRetainedSize();
+            assertTrue(retainedSize > bufferSize && retainedSize < length);
+        }
+    }
+
+    protected void assertRetainedSize(SliceInput input)
+    {
+        long retainedSize = ClassLayout.parseClass(input.getClass()).instanceSize();
+        Field[] fields = input.getClass().getDeclaredFields();
+
+        for (Field field : fields) {
+            Class<?> type = field.getType();
+            // we skip the array fields since jacoco mvn plugin instruments the classes during
+            // tests and add a boolean array field (boolean[] io.airlift.slice.ChunkedSliceInput.$jacocoData)
+            // https://github.com/jacoco/jacoco/issues/168
+            if (type.isPrimitive() || type.isArray()) {
+                continue;
+            }
+
+            field.setAccessible(true);
+
+            try {
+                Object value = field.get(input);
+                retainedSize += (long) value.getClass().getDeclaredMethod("getRetainedSize").invoke(value);
+            }
+            catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        assertEquals(input.getRetainedSize(), retainedSize);
     }
 }

--- a/src/test/java/io/airlift/slice/TestInputStreamSliceInput.java
+++ b/src/test/java/io/airlift/slice/TestInputStreamSliceInput.java
@@ -13,10 +13,12 @@
  */
 package io.airlift.slice;
 
+import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 
+import static io.airlift.slice.SizeOf.sizeOfByteArray;
 import static org.testng.Assert.assertEquals;
 
 public class TestInputStreamSliceInput
@@ -148,6 +150,14 @@ public class TestInputStreamSliceInput
         assertEquals(buildSliceInput(new byte[] {0, 0, -64, 127}).readFloat(), Float.NaN);
         assertEquals(buildSliceInput(new byte[] {0, 0, -128, -1}).readFloat(), Float.NEGATIVE_INFINITY);
         assertEquals(buildSliceInput(new byte[] {0, 0, -128, 127}).readFloat(), Float.POSITIVE_INFINITY);
+    }
+
+    @Test
+    public void testRetainedSize()
+    {
+        int bufferSize = 1024;
+        InputStreamSliceInput input = new InputStreamSliceInput(new ByteArrayInputStream(new byte[] {0, 1}), bufferSize);
+        assertEquals(input.getRetainedSize(), ClassLayout.parseClass(InputStreamSliceInput.class).instanceSize() + sizeOfByteArray(bufferSize));
     }
 
     private SliceInput buildSliceInput(byte[] bytes)


### PR DESCRIPTION
Users of this class may need to get an approximation of the retained
size of instances of this class for memory tracking.