### PR TITLE
Fix BasicSliceInput::getRetainedSize

### DIFF
--- a/src/main/java/io/airlift/slice/BasicSliceInput.java
+++ b/src/main/java/io/airlift/slice/BasicSliceInput.java
@@ -217,7 +217,10 @@ public final class BasicSliceInput
     @Override
     public long getRetainedSize()
     {
-        return INSTANCE_SIZE + slice.getRetainedSize();
+        // Multiple slices can share the same underlying base array, so instead of
+        // slice.getRetainedSize() we use slice.length() here to approximate the memory usage.
+        // Using slice.getRetainedSize() will result in over-accounting.
+        return INSTANCE_SIZE + slice.length();
     }
 
     /**

--- a/src/test/java/io/airlift/slice/TestBasicSliceInput.java
+++ b/src/test/java/io/airlift/slice/TestBasicSliceInput.java
@@ -32,6 +32,6 @@ public class TestBasicSliceInput
     {
         Slice slice = Slices.allocate(1024);
         SliceInput input = new BasicSliceInput(slice);
-        assertEquals(input.getRetainedSize(), ClassLayout.parseClass(BasicSliceInput.class).instanceSize() + slice.getRetainedSize());
+        assertEquals(input.getRetainedSize(), ClassLayout.parseClass(BasicSliceInput.class).instanceSize() + slice.length());
     }
 }


### PR DESCRIPTION
Since multiple slices can share the same underlying base array, using
slice.getRetainedSize() for calculating the retained size of a
BasicSliceInput input may result in over-accounting. This change
fixes that by using slice.length() to approximate the memory usage
of BasicSliceInput instances.