### PR TITLE
Return zero positioned HeapByteBuffer from Slice#toByteBuffer

### DIFF
--- a/src/main/java/io/airlift/slice/JvmUtils.java
+++ b/src/main/java/io/airlift/slice/JvmUtils.java
@@ -34,7 +34,8 @@ import static sun.misc.Unsafe.ARRAY_SHORT_INDEX_SCALE;
 final class JvmUtils
 {
     static final Unsafe unsafe;
-    static final MethodHandle newByteBuffer;
+    static final MethodHandle newDirectByteBuffer;
+    static final MethodHandle newHeapByteBuffer;
 
     private static final Field ADDRESS_ACCESSOR;
 
@@ -59,10 +60,16 @@ final class JvmUtils
 
             // fetch a method handle for the hidden constructor for DirectByteBuffer
             Class<?> directByteBufferClass = ClassLoader.getSystemClassLoader().loadClass("java.nio.DirectByteBuffer");
-            Constructor<?> constructor = directByteBufferClass.getDeclaredConstructor(long.class, int.class, Object.class);
-            constructor.setAccessible(true);
-            newByteBuffer = MethodHandles.lookup().unreflectConstructor(constructor)
+            Constructor<?> directByteBufferConstructor = directByteBufferClass.getDeclaredConstructor(long.class, int.class, Object.class);
+            directByteBufferConstructor.setAccessible(true);
+            newDirectByteBuffer = MethodHandles.lookup().unreflectConstructor(directByteBufferConstructor)
                     .asType(MethodType.methodType(ByteBuffer.class, long.class, int.class, Object.class));
+
+            Class<?> heapByteBufferClass = ClassLoader.getSystemClassLoader().loadClass("java.nio.HeapByteBuffer");
+            Constructor<?> heapByteBufferConstructor = heapByteBufferClass.getDeclaredConstructor(byte[].class, int.class, int.class, int.class, int.class, int.class);
+            heapByteBufferConstructor.setAccessible(true);
+            newHeapByteBuffer = MethodHandles.lookup().unreflectConstructor(heapByteBufferConstructor)
+                    .asType(MethodType.methodType(ByteBuffer.class, byte[].class, int.class, int.class, int.class, int.class, int.class));
 
             ADDRESS_ACCESSOR = Buffer.class.getDeclaredField("address");
             ADDRESS_ACCESSOR.setAccessible(true);

--- a/src/main/java/io/airlift/slice/JvmUtils.java
+++ b/src/main/java/io/airlift/slice/JvmUtils.java
@@ -74,7 +74,7 @@ final class JvmUtils
             ADDRESS_ACCESSOR = Buffer.class.getDeclaredField("address");
             ADDRESS_ACCESSOR.setAccessible(true);
         }
-        catch (Exception e) {
+        catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/io/airlift/slice/TestSlice.java
+++ b/src/test/java/io/airlift/slice/TestSlice.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -821,6 +822,25 @@ public class TestSlice
         }
 
         assertEquals(bruteForce, indexOf);
+    }
+
+    @Test
+    public void testToByteBuffer()
+    {
+        Slice full = allocate(10);
+        for (int i = 0; i < 10; i++) {
+            full.setByte(i, i);
+        }
+        Slice chunk = full.slice(5, 5);
+        ByteBuffer zeroOffsetBuffer = chunk.toByteBuffer();
+        assertEquals(zeroOffsetBuffer.position(), 0);
+        for (int i = 0; i < 5; i++) {
+            assertEquals(zeroOffsetBuffer.get(i), chunk.getByte(i));
+        }
+        ByteBuffer nonZeroOffsetBuffer = chunk.toByteBuffer(1, 4);
+        for (int i = 0; i < 4; i++) {
+            assertEquals(nonZeroOffsetBuffer.get(i), chunk.getByte(i + 1));
+        }
     }
 
     private static List<Long> createRandomLongs(int count)


### PR DESCRIPTION
The direct ByteBuffer was already zero positioned.
Returning non zero positioned ByteBuffer is error prone.
Various ByteBuffer#get(index) methods don't apply the position to the offset.