### PR TITLE
Slice methods for byte array access

### DIFF
--- a/src/test/java/io/airlift/slice/TestSlice.java
+++ b/src/test/java/io/airlift/slice/TestSlice.java
@@ -162,6 +162,20 @@ public class TestSlice
         }
     }
 
+    @Test
+    public void testBackingByteArray()
+    {
+        byte[] bytes = new byte[Byte.MAX_VALUE];
+        for (int i = 0; i < bytes.length; i++) {
+            Slice slice = Slices.wrappedBuffer(bytes, i, bytes.length - i);
+            assertTrue(slice.hasByteArray());
+            assertEquals(slice.byteArrayOffset(), i);
+            assertSame(slice.byteArray(), bytes);
+            bytes[i] = (byte) i;
+            assertEquals(slice.getByte(0), (byte) i);
+        }
+    }
+
     private static void assertSlicesEquals(Slice slice, Slice other)
     {
         int size = slice.length();

--- a/src/test/java/io/airlift/slice/TestSlices.java
+++ b/src/test/java/io/airlift/slice/TestSlices.java
@@ -38,7 +38,9 @@ import static io.airlift.slice.Slices.wrappedIntArray;
 import static io.airlift.slice.Slices.wrappedLongArray;
 import static io.airlift.slice.Slices.wrappedShortArray;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 public class TestSlices
 {
@@ -104,42 +106,49 @@ public class TestSlices
         assertEquals(wrappedBooleanArray(booleanArray, 1, 4).getByte(0) == 1, booleanArray[1]);
         assertEquals(wrappedBooleanArray(booleanArray, 1, 4).length(), 4 * SIZE_OF_BYTE);
         assertEquals(wrappedBooleanArray(booleanArray).getByte(5 * SIZE_OF_BYTE) == 1, booleanArray[5]);
+        assertFalse(wrappedBooleanArray(booleanArray).hasByteArray());
 
         byte[] byteArray = {(byte) 0, (byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5};
         assertEquals(wrappedBuffer(byteArray).getByte(0), byteArray[0]);
         assertEquals(wrappedBuffer(byteArray, 1, 4).getByte(0), byteArray[1]);
         assertEquals(wrappedBuffer(byteArray, 1, 4).length(), 4 * SIZE_OF_BYTE);
         assertEquals(wrappedBuffer(byteArray).getByte(5 * SIZE_OF_BYTE), byteArray[5]);
+        assertTrue(wrappedBuffer(byteArray).hasByteArray());
 
         short[] shortArray = {(short) 0, (short) 1, (short) 2, (short) 3, (short) 4, (short) 5};
         assertEquals(wrappedShortArray(shortArray).getShort(0), shortArray[0]);
         assertEquals(wrappedShortArray(shortArray, 1, 4).getShort(0), shortArray[1]);
         assertEquals(wrappedShortArray(shortArray, 1, 4).length(), 4 * SIZE_OF_SHORT);
         assertEquals(wrappedShortArray(shortArray).getShort(5 * SIZE_OF_SHORT), shortArray[5]);
+        assertFalse(wrappedShortArray(shortArray).hasByteArray());
 
         int[] intArray = {0, 1, 2, 3, 4, 5};
         assertEquals(wrappedIntArray(intArray).getInt(0), intArray[0]);
         assertEquals(wrappedIntArray(intArray, 1, 4).getInt(0), intArray[1]);
         assertEquals(wrappedIntArray(intArray, 1, 4).length(), 4 * SIZE_OF_INT);
         assertEquals(wrappedIntArray(intArray).getInt(5 * SIZE_OF_INT), intArray[5]);
+        assertFalse(wrappedIntArray(intArray).hasByteArray());
 
         long[] longArray = {0L, 1L, 2L, 3L, 4L, 5L};
         assertEquals(wrappedLongArray(longArray).getLong(0), longArray[0]);
         assertEquals(wrappedLongArray(longArray, 1, 4).getLong(0), longArray[1]);
         assertEquals(wrappedLongArray(longArray, 1, 4).length(), 4 * SIZE_OF_LONG);
         assertEquals(wrappedLongArray(longArray).getLong(5 * SIZE_OF_LONG), longArray[5]);
+        assertFalse(wrappedLongArray(longArray).hasByteArray());
 
         float[] floatArray = {0f, 1f, 2f, 3f, 4f, 5f};
         assertEquals(wrappedFloatArray(floatArray).getFloat(0), floatArray[0]);
         assertEquals(wrappedFloatArray(floatArray, 1, 4).getFloat(0), floatArray[1]);
         assertEquals(wrappedFloatArray(floatArray, 1, 4).length(), 4 * SIZE_OF_FLOAT);
         assertEquals(wrappedFloatArray(floatArray).getFloat(5 * SIZE_OF_FLOAT), floatArray[5]);
+        assertFalse(wrappedFloatArray(floatArray).hasByteArray());
 
         double[] doubleArray = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0};
         assertEquals(wrappedDoubleArray(doubleArray).getDouble(0), doubleArray[0]);
         assertEquals(wrappedDoubleArray(doubleArray, 1, 4).getDouble(0), doubleArray[1]);
         assertEquals(wrappedDoubleArray(doubleArray, 1, 4).length(), 4 * SIZE_OF_DOUBLE);
         assertEquals(wrappedDoubleArray(doubleArray).getDouble(5 * SIZE_OF_DOUBLE), doubleArray[5]);
+        assertFalse(wrappedDoubleArray(doubleArray).hasByteArray());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Cannot allocate slice larger than 2147483639 bytes")


### PR DESCRIPTION
Adds methods to Slice similar to `ByteBuffer::{hasArray, array, arrayOffset}` so that external code can more easily access the underlying byte array if one exists.