### PR TITLE
Implement batch double[] read/writes for Slice

### DIFF
--- a/src/main/java/io/airlift/slice/BasicSliceInput.java
+++ b/src/main/java/io/airlift/slice/BasicSliceInput.java
@@ -151,6 +151,13 @@ public final class BasicSliceInput
     }
 
     @Override
+    public void readDoubles(double[] destination, int destinationIndex, int length)
+    {
+        slice.getDoubles(position, destination, destinationIndex, length);
+        position += length * SIZE_OF_DOUBLE;
+    }
+
+    @Override
     public Slice readSlice(int length)
     {
         if (length == 0) {

--- a/src/main/java/io/airlift/slice/BasicSliceOutput.java
+++ b/src/main/java/io/airlift/slice/BasicSliceOutput.java
@@ -122,6 +122,13 @@ public class BasicSliceOutput
     }
 
     @Override
+    public void writeDoubles(double[] source, int sourceIndex, int length)
+    {
+        slice.setDoubles(size, source, sourceIndex, length);
+        size += length * SIZE_OF_DOUBLE;
+    }
+
+    @Override
     public void writeBytes(byte[] source, int sourceIndex, int length)
     {
         slice.setBytes(size, source, sourceIndex, length);

--- a/src/main/java/io/airlift/slice/ChunkedSliceInput.java
+++ b/src/main/java/io/airlift/slice/ChunkedSliceInput.java
@@ -197,6 +197,15 @@ public final class ChunkedSliceInput
     }
 
     @Override
+    public void readDoubles(double[] destination, int destinationIndex, int length)
+    {
+        int lengthInBytes = length * SIZE_OF_DOUBLE;
+        ensureAvailable(lengthInBytes);
+        buffer.getDoubles(bufferPosition, destination, destinationIndex, length);
+        bufferPosition += lengthInBytes;
+    }
+
+    @Override
     public Slice readSlice(int length)
     {
         if (length == 0) {

--- a/src/main/java/io/airlift/slice/DynamicSliceOutput.java
+++ b/src/main/java/io/airlift/slice/DynamicSliceOutput.java
@@ -127,6 +127,14 @@ public class DynamicSliceOutput
     }
 
     @Override
+    public void writeDoubles(double[] source, int sourceIndex, int length)
+    {
+        slice = Slices.ensureSize(slice, size + length * SIZE_OF_DOUBLE);
+        slice.setDoubles(size, source, sourceIndex, length);
+        size += length * SIZE_OF_DOUBLE;
+    }
+
+    @Override
     public void writeBytes(byte[] source)
     {
         writeBytes(source, 0, source.length);

--- a/src/main/java/io/airlift/slice/InputStreamSliceInput.java
+++ b/src/main/java/io/airlift/slice/InputStreamSliceInput.java
@@ -23,6 +23,7 @@ import java.io.UncheckedIOException;
 import static io.airlift.slice.Preconditions.checkArgument;
 import static io.airlift.slice.Preconditions.verify;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
@@ -165,6 +166,15 @@ public final class InputStreamSliceInput
     public double readDouble()
     {
         return Double.longBitsToDouble(readLong());
+    }
+
+    @Override
+    public void readDoubles(double[] destination, int destinationIndex, int length)
+    {
+        int lengthInBytes = length * SIZE_OF_DOUBLE;
+        ensureAvailable(lengthInBytes);
+        slice.getDoubles(bufferPosition, destination, destinationIndex, length);
+        bufferPosition += lengthInBytes;
     }
 
     @Override

--- a/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
+++ b/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 
 import static io.airlift.slice.Preconditions.checkArgument;
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
@@ -168,6 +169,23 @@ public class OutputStreamSliceOutput
     public void writeDouble(double value)
     {
         writeLong(Double.doubleToLongBits(value));
+    }
+
+    @Override
+    public void writeDoubles(double[] source, int sourceIndex, int length)
+    {
+        int lengthInBytes = length * SIZE_OF_DOUBLE;
+        if (lengthInBytes >= MINIMUM_CHUNK_SIZE) {
+            flushBufferToOutputStream();
+            Slice slice = new Slice(source, sourceIndex, length);
+            writeToOutputStream(slice, 0, lengthInBytes);
+            bufferOffset += lengthInBytes;
+        }
+        else {
+            ensureWritableBytes(lengthInBytes);
+            slice.setDoubles(bufferPosition, source, sourceIndex, length);
+            bufferPosition += lengthInBytes;
+        }
     }
 
     @Override

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -540,7 +540,47 @@ public final class Slice
     public double getDouble(int index)
     {
         checkIndexLength(index, SIZE_OF_DOUBLE);
+        return getDoubleUnchecked(index);
+    }
+
+    double getDoubleUnchecked(int index)
+    {
         return unsafe.getDouble(base, address + index);
+    }
+
+    /**
+     * Transfers portion of data from this slice as doubles into the specified
+     * destination starting at the specified absolute {@code index}.
+     *
+     * @param destinationIndex the first index of the destination
+     * @param length the number of doubles to transfer
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * if the specified {@code destinationIndex} is less than {@code 0},
+     * if {@code index + length * 8} is greater than * {@code this.length()},
+     * or if {@code destinationIndex + length} is greater than {@code destination.length}
+     */
+    public void getDoubles(int index, double[] destination, int destinationIndex, int length)
+    {
+        int lengthInBytes = length * SIZE_OF_DOUBLE;
+        checkIndexLength(index, lengthInBytes);
+        checkPositionIndexes(destinationIndex, destinationIndex + length, destination.length);
+        for (int i = 0; i < length; i++) {
+            destination[i] = getDoubleUnchecked(index + i * SIZE_OF_DOUBLE);
+        }
+    }
+
+    /**
+     * Gets an array of {@code length} 64-bit doubles from the absolute
+     * {@code index} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0} or
+     * {@code index + 8 * length} is greater than {@code this.length()}
+     */
+    public double[] getDoubles(int index, int length)
+    {
+        double[] doubles = new double[length];
+        getDoubles(index, doubles, 0, length);
+        return doubles;
     }
 
     /**
@@ -756,6 +796,38 @@ public final class Slice
     {
         checkIndexLength(index, SIZE_OF_DOUBLE);
         unsafe.putDouble(base, address + index, value);
+    }
+
+    /**
+     * Sets the specified 64-bit doubles at the specified absolute
+     * {@code index} in this buffer.
+     *
+     * @param sourceIndex start reading from this index in {@code source}
+     * @param length read and write exactly this many doubles
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * or {@code index + length * 8} is greater than {@code this.length()},
+     * or {@code sourceIndex < 0},
+     * or {@code source.length < sourceIndex + length}
+     */
+    public void setDoubles(int index, double[] source, int sourceIndex, int length)
+    {
+        checkPositionIndexes(sourceIndex, sourceIndex + length, source.length);
+        checkIndexLength(index, length * SIZE_OF_DOUBLE);
+        for (int i = 0; i < length; i++) {
+            unsafe.putDouble(base, address + index + i * SIZE_OF_DOUBLE, source[sourceIndex + i]);
+        }
+    }
+
+    /**
+     * Sets the specified 64-bit doubles at the specified absolute
+     * {@code index} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0} or
+     * {@code index + values.length * 8} is greater than {@code this.length()}
+     */
+    public void setDoubles(int index, double[] source)
+    {
+        setDoubles(index, source, 0, source.length);
     }
 
     /**

--- a/src/main/java/io/airlift/slice/SliceInput.java
+++ b/src/main/java/io/airlift/slice/SliceInput.java
@@ -146,6 +146,28 @@ public abstract class SliceInput
     public abstract double readDouble();
 
     /**
+     * Transfers {@code length * 8} bytes this buffer's data as doubles to the
+     * specified destination starting at the current {@code position} and
+     * increases the {@code position} by the number of the transferred bytes.
+     *
+     * @throws IndexOutOfBoundsException if {@code this.available()} is less than {@code length * 8}
+     */
+    public abstract void readDoubles(double[] destination, int destinationIndex, int length);
+
+    /**
+     * Gets exactly {@code length} doubles at the current {@code position},
+     * increasing the {@code position} by {@code length * 8} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException if {@code this.available()} is less than {@code length * 8}
+     */
+    public double[] readDoubles(int length)
+    {
+        double[] destination = new double[length];
+        readDoubles(destination, 0, length);
+        return destination;
+    }
+
+    /**
      * Returns a new slice of this buffer's sub-region starting at the current
      * {@code position} and increases the {@code position} by the size
      * of the new slice (= {@code length}).

--- a/src/main/java/io/airlift/slice/SliceOutput.java
+++ b/src/main/java/io/airlift/slice/SliceOutput.java
@@ -128,6 +128,29 @@ public abstract class SliceOutput
     public abstract void writeDouble(double value);
 
     /**
+     * Write doubles in {@code source} into the slice at the current position,
+     * increasing the {@code writerIndex} by {@code length * 8} in this buffer.
+     *
+     * @param sourceIndex start reading from this index in {@code source}
+     * @param length read and write exactly this many doubles
+     * @throws IndexOutOfBoundsException if {@code this.writableBytes} is less than {@code length * 8},
+     * or {@code sourceIndex < 0},
+     * or {@code source.length < sourceIndex + length}
+     */
+    public abstract void writeDoubles(double[] source, int sourceIndex, int length);
+
+    /**
+     * Write the doubles in {@code value} into the slice at the current position,
+     * increasing the {@code writerIndex} by {@code values.length * 8} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException if {@code this.writableBytes} is less than {@code values.length * 8}
+     */
+    public void writeDoubles(double[] source)
+    {
+        writeDoubles(source, 0, source.length);
+    }
+
+    /**
      * Transfers the specified source buffer's data to this buffer starting at
      * the current {@code writerIndex} until the source buffer becomes
      * unreadable, and increases the {@code writerIndex} by the number of

--- a/src/test/java/io/airlift/slice/TestSlice.java
+++ b/src/test/java/io/airlift/slice/TestSlice.java
@@ -538,6 +538,68 @@ public class TestSlice
     }
 
     @Test
+    public void testDoubles()
+    {
+        for (int size = 0; size < 100; size++) {
+            for (int index = 0; index < (size - SIZE_OF_DOUBLE); index++) {
+                assertDoubles(allocate(size), index);
+            }
+        }
+    }
+
+    private static void assertDoubles(Slice slice, int index)
+    {
+        double[] value = new double[(slice.length() - index) / SIZE_OF_DOUBLE];
+        Arrays.fill(value, longBitsToDouble(0xAAAA_AAAA_5555_5555L));
+
+        slice.fill((byte) 0xFF);
+        slice.setDoubles(index, value);
+        assertEquals(slice.getDoubles(index, value.length), value);
+
+        value = new double[(slice.length() - index) / SIZE_OF_DOUBLE / 2];
+        Arrays.fill(value, longBitsToDouble(0xAAAA_AAAA_5555_5555L));
+
+        slice.fill((byte) 0xFF);
+        slice.setDoubles(index, value);
+        assertEquals(slice.getDoubles(index, value.length), value);
+
+        try {
+            slice.getDoubles(-1, 1);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException e) {
+        }
+
+        try {
+            slice.getDoubles((slice.length() - SIZE_OF_DOUBLE) + 1, 1);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException e) {
+        }
+
+        try {
+            slice.getDoubles(slice.length(), 1);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException e) {
+        }
+
+        try {
+            slice.getDoubles(slice.length() + 1, 1);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException e) {
+        }
+
+        try {
+            slice.getDoubles(slice.length() / 2, slice.length() / 4);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException e) {
+        }
+    }
+
+    @Test
     public void testBytesArray()
     {
         for (int size = 0; size < 100; size++) {


### PR DESCRIPTION
If multiple doubles are read from/written to a slice, bounds checking
and allocations take up a significant fraction of CPU.  When writing as
a batch, do the allocations and bounds checking only once.

Geometry serde often involves thousands (or millions) of doubles as
coordinates.  Using these methods can reduce the serde CPU cost by
50%-80% for complex geometries.

In this PR, I've implemented `Slice.setDoubles()`/`getDoubles()`, and
`SliceInput.readDoubles()` (including those classes that implement
`SliceInput`.  I've only implemented `DynamicOutputSlice.writeDoubles()`,
because I wanted to get feedback on this PR before going further.

Here's a flame graph just using `readDouble` repeated:
<img width="1199" alt="flamegraph-bound-checks" src="https://user-images.githubusercontent.com/495664/72477391-691bd600-37bd-11ea-8eac-e89eac87a08c.png">

And here's one with the new code:
<img width="1200" alt="flamegraph-no-bound-checks" src="https://user-images.githubusercontent.com/495664/72477410-73d66b00-37bd-11ea-8a43-dc9fb48aa7dd.png">

Additionally, the new code increases throughput benchmarks by about 2x.
