### PR TITLE
Mark Slice(boolean[] base) as deprecated

### DIFF
--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -160,6 +160,7 @@ public final class Slice
      * @param offset the array position at which the slice begins
      * @param length the number of array positions to include in the slice
      */
+    @Deprecated(forRemoval = true)
     Slice(boolean[] base, int offset, int length)
     {
         requireNonNull(base, "base is null");

--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -157,6 +157,7 @@ public final class Slices
     /**
      * Creates a slice over the specified array.
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedBooleanArray(boolean... array)
     {
         return wrappedBooleanArray(array, 0, array.length);
@@ -168,6 +169,7 @@ public final class Slices
      * @param offset the array position at which the slice begins
      * @param length the number of array positions to include in the slice
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedBooleanArray(boolean[] array, int offset, int length)
     {
         if (length == 0) {


### PR DESCRIPTION
Creating a Slice from boolean array is not used in Trino

When Slice is reimplemented in the future on top of the JEP 424, creating a MemorySegment from a boolean array won't be possible so it's better to deprecate it early.