### PR TITLE
Deprecate support for Slice not backed by a byte[] for removal

### DIFF
--- a/src/main/java/io/airlift/slice/BasicSliceInput.java
+++ b/src/main/java/io/airlift/slice/BasicSliceInput.java
@@ -202,6 +202,41 @@ public final class BasicSliceInput
     }
 
     @Override
+    public void readShorts(short[] destination, int destinationIndex, int length)
+    {
+        slice.getShorts(position, destination, destinationIndex, length);
+        position += length * Short.BYTES;
+    }
+
+    @Override
+    public void readInts(int[] destination, int destinationIndex, int length)
+    {
+        slice.getInts(position, destination, destinationIndex, length);
+        position += length * Integer.BYTES;
+    }
+
+    @Override
+    public void readLongs(long[] destination, int destinationIndex, int length)
+    {
+        slice.getLongs(position, destination, destinationIndex, length);
+        position += length * Long.BYTES;
+    }
+
+    @Override
+    public void readFloats(float[] destination, int destinationIndex, int length)
+    {
+        slice.getFloats(position, destination, destinationIndex, length);
+        position += length * Float.BYTES;
+    }
+
+    @Override
+    public void readDoubles(double[] destination, int destinationIndex, int length)
+    {
+        slice.getDoubles(position, destination, destinationIndex, length);
+        position += length * Double.BYTES;
+    }
+
+    @Override
     public long skip(long length)
     {
         length = Math.min(length, available());

--- a/src/main/java/io/airlift/slice/BasicSliceOutput.java
+++ b/src/main/java/io/airlift/slice/BasicSliceOutput.java
@@ -136,6 +136,41 @@ public class BasicSliceOutput
     }
 
     @Override
+    public void writeShorts(short[] source, int sourceIndex, int length)
+    {
+        slice.setShorts(size, source, sourceIndex, length);
+        size += length * Short.BYTES;
+    }
+
+    @Override
+    public void writeInts(int[] source, int sourceIndex, int length)
+    {
+        slice.setInts(size, source, sourceIndex, length);
+        size += length * Integer.BYTES;
+    }
+
+    @Override
+    public void writeLongs(long[] source, int sourceIndex, int length)
+    {
+        slice.setLongs(size, source, sourceIndex, length);
+        size += length * Long.BYTES;
+    }
+
+    @Override
+    public void writeFloats(float[] source, int sourceIndex, int length)
+    {
+        slice.setFloats(size, source, sourceIndex, length);
+        size += length * Float.BYTES;
+    }
+
+    @Override
+    public void writeDoubles(double[] source, int sourceIndex, int length)
+    {
+        slice.setDoubles(size, source, sourceIndex, length);
+        size += length * Double.BYTES;
+    }
+
+    @Override
     public void writeBytes(Slice source)
     {
         writeBytes(source, 0, source.length());

--- a/src/main/java/io/airlift/slice/ChunkedSliceInput.java
+++ b/src/main/java/io/airlift/slice/ChunkedSliceInput.java
@@ -277,6 +277,91 @@ public final class ChunkedSliceInput
     }
 
     @Override
+    public void readShorts(short[] destination, int destinationIndex, int length)
+    {
+        checkBound(position() + ((long) length * Short.BYTES), globalLength, "End of stream");
+
+        while (length > 0) {
+            int shortsToRead = min(available() / Short.BYTES, length);
+            buffer.getShorts(bufferPosition, destination, destinationIndex, shortsToRead);
+
+            bufferPosition += shortsToRead * Short.BYTES;
+            length -= shortsToRead;
+            destinationIndex += shortsToRead;
+
+            ensureAvailable(min(length * Short.BYTES, buffer.length()));
+        }
+    }
+
+    @Override
+    public void readInts(int[] destination, int destinationIndex, int length)
+    {
+        checkBound(position() + ((long) length * Integer.BYTES), globalLength, "End of stream");
+
+        while (length > 0) {
+            int intsToRead = min(available() / Integer.BYTES, length);
+            buffer.getInts(bufferPosition, destination, destinationIndex, intsToRead);
+
+            bufferPosition += intsToRead * Integer.BYTES;
+            length -= intsToRead;
+            destinationIndex += intsToRead;
+
+            ensureAvailable(min(length * Integer.BYTES, buffer.length()));
+        }
+    }
+
+    @Override
+    public void readLongs(long[] destination, int destinationIndex, int length)
+    {
+        checkBound(position() + ((long) length * Long.BYTES), globalLength, "End of stream");
+
+        while (length > 0) {
+            int longsToRead = min(available() / Long.BYTES, length);
+            buffer.getLongs(bufferPosition, destination, destinationIndex, longsToRead);
+
+            bufferPosition += longsToRead * Long.BYTES;
+            length -= longsToRead;
+            destinationIndex += longsToRead;
+
+            ensureAvailable(min(length * Long.BYTES, buffer.length()));
+        }
+    }
+
+    @Override
+    public void readFloats(float[] destination, int destinationIndex, int length)
+    {
+        checkBound(position() + ((long) length * Float.BYTES), globalLength, "End of stream");
+
+        while (length > 0) {
+            int floatsToRead = min(available() / Float.BYTES, length);
+            buffer.getFloats(bufferPosition, destination, destinationIndex, floatsToRead);
+
+            bufferPosition += floatsToRead * Float.BYTES;
+            length -= floatsToRead;
+            destinationIndex += floatsToRead;
+
+            ensureAvailable(min(length * Float.BYTES, buffer.length()));
+        }
+    }
+
+    @Override
+    public void readDoubles(double[] destination, int destinationIndex, int length)
+    {
+        checkBound(position() + ((long) length * Double.BYTES), globalLength, "End of stream");
+
+        while (length > 0) {
+            int doublesToRead = min(available() / Double.BYTES, length);
+            buffer.getDoubles(bufferPosition, destination, destinationIndex, doublesToRead);
+
+            bufferPosition += doublesToRead * Double.BYTES;
+            length -= doublesToRead;
+            destinationIndex += doublesToRead;
+
+            ensureAvailable(min(length * Double.BYTES, buffer.length()));
+        }
+    }
+
+    @Override
     public long skip(long length)
     {
         // is skip within the current buffer?

--- a/src/main/java/io/airlift/slice/DynamicSliceOutput.java
+++ b/src/main/java/io/airlift/slice/DynamicSliceOutput.java
@@ -142,6 +142,46 @@ public class DynamicSliceOutput
     }
 
     @Override
+    public void writeShorts(short[] source, int sourceIndex, int length)
+    {
+        slice = Slices.ensureSize(slice, size + length * Short.BYTES);
+        slice.setShorts(size, source, sourceIndex, length);
+        size += length * Short.BYTES;
+    }
+
+    @Override
+    public void writeInts(int[] source, int sourceIndex, int length)
+    {
+        slice = Slices.ensureSize(slice, size + length * Integer.BYTES);
+        slice.setInts(size, source, sourceIndex, length);
+        size += length * Integer.BYTES;
+    }
+
+    @Override
+    public void writeLongs(long[] source, int sourceIndex, int length)
+    {
+        slice = Slices.ensureSize(slice, size + length * Long.BYTES);
+        slice.setLongs(size, source, sourceIndex, length);
+        size += length * Long.BYTES;
+    }
+
+    @Override
+    public void writeFloats(float[] source, int sourceIndex, int length)
+    {
+        slice = Slices.ensureSize(slice, size + length * Float.BYTES);
+        slice.setFloats(size, source, sourceIndex, length);
+        size += length * Float.BYTES;
+    }
+
+    @Override
+    public void writeDoubles(double[] source, int sourceIndex, int length)
+    {
+        slice = Slices.ensureSize(slice, size + length * Double.BYTES);
+        slice.setDoubles(size, source, sourceIndex, length);
+        size += length * Double.BYTES;
+    }
+
+    @Override
     public void writeBytes(Slice source)
     {
         writeBytes(source, 0, source.length());

--- a/src/main/java/io/airlift/slice/InputStreamSliceInput.java
+++ b/src/main/java/io/airlift/slice/InputStreamSliceInput.java
@@ -233,6 +233,81 @@ public final class InputStreamSliceInput
     }
 
     @Override
+    public void readShorts(short[] destination, int destinationIndex, int length)
+    {
+        while (length > 0) {
+            int batch = Math.min(availableBytes(), length * Short.BYTES) / Short.BYTES;
+            slice.getShorts(bufferPosition, destination, destinationIndex, batch);
+
+            bufferPosition += batch * Short.BYTES;
+            destinationIndex += batch;
+            length -= batch;
+
+            ensureAvailable(Math.min(length * Short.BYTES, MINIMUM_CHUNK_SIZE));
+        }
+    }
+
+    @Override
+    public void readInts(int[] destination, int destinationIndex, int length)
+    {
+        while (length > 0) {
+            int batch = Math.min(availableBytes(), length * Integer.BYTES) / Integer.BYTES;
+            slice.getInts(bufferPosition, destination, destinationIndex, batch);
+
+            bufferPosition += batch * Integer.BYTES;
+            destinationIndex += batch;
+            length -= batch;
+
+            ensureAvailable(Math.min(length * Integer.BYTES, MINIMUM_CHUNK_SIZE));
+        }
+    }
+
+    @Override
+    public void readLongs(long[] destination, int destinationIndex, int length)
+    {
+        while (length > 0) {
+            int batch = Math.min(availableBytes(), length * Long.BYTES) / Long.BYTES;
+            slice.getLongs(bufferPosition, destination, destinationIndex, batch);
+
+            bufferPosition += batch * Long.BYTES;
+            destinationIndex += batch;
+            length -= batch;
+
+            ensureAvailable(Math.min(length * Long.BYTES, MINIMUM_CHUNK_SIZE));
+        }
+    }
+
+    @Override
+    public void readFloats(float[] destination, int destinationIndex, int length)
+    {
+        while (length > 0) {
+            int batch = Math.min(availableBytes(), length * Float.BYTES) / Float.BYTES;
+            slice.getFloats(bufferPosition, destination, destinationIndex, batch);
+
+            bufferPosition += batch * Float.BYTES;
+            destinationIndex += batch;
+            length -= batch;
+
+            ensureAvailable(Math.min(length * Float.BYTES, MINIMUM_CHUNK_SIZE));
+        }
+    }
+
+    @Override
+    public void readDoubles(double[] destination, int destinationIndex, int length)
+    {
+        while (length > 0) {
+            int batch = Math.min(availableBytes(), length * Double.BYTES) / Double.BYTES;
+            slice.getDoubles(bufferPosition, destination, destinationIndex, batch);
+
+            bufferPosition += batch * Double.BYTES;
+            destinationIndex += batch;
+            length -= batch;
+
+            ensureAvailable(Math.min(length * Double.BYTES, MINIMUM_CHUNK_SIZE));
+        }
+    }
+
+    @Override
     public Slice readSlice(int length)
     {
         if (length == 0) {

--- a/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
+++ b/src/main/java/io/airlift/slice/OutputStreamSliceOutput.java
@@ -218,6 +218,66 @@ public class OutputStreamSliceOutput
     }
 
     @Override
+    public void writeShorts(short[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int batch = ensureBatchSize(length * Short.BYTES) / Short.BYTES;
+            slice.setShorts(bufferPosition, source, sourceIndex, batch);
+            bufferPosition += batch * Short.BYTES;
+            sourceIndex += batch;
+            length -= batch;
+        }
+    }
+
+    @Override
+    public void writeInts(int[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int batch = ensureBatchSize(length * Integer.BYTES) / Integer.BYTES;
+            slice.setInts(bufferPosition, source, sourceIndex, batch);
+            bufferPosition += batch * Integer.BYTES;
+            sourceIndex += batch;
+            length -= batch;
+        }
+    }
+
+    @Override
+    public void writeLongs(long[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int batch = ensureBatchSize(length * Long.BYTES) / Long.BYTES;
+            slice.setLongs(bufferPosition, source, sourceIndex, batch);
+            bufferPosition += batch * Long.BYTES;
+            sourceIndex += batch;
+            length -= batch;
+        }
+    }
+
+    @Override
+    public void writeFloats(float[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int batch = ensureBatchSize(length * Float.BYTES) / Float.BYTES;
+            slice.setFloats(bufferPosition, source, sourceIndex, batch);
+            bufferPosition += batch * Float.BYTES;
+            sourceIndex += batch;
+            length -= batch;
+        }
+    }
+
+    @Override
+    public void writeDoubles(double[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int batch = ensureBatchSize(length * Double.BYTES) / Double.BYTES;
+            slice.setDoubles(bufferPosition, source, sourceIndex, batch);
+            bufferPosition += batch * Double.BYTES;
+            sourceIndex += batch;
+            length -= batch;
+        }
+    }
+
+    @Override
     public void writeBytes(InputStream in, int length)
             throws IOException
     {

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -64,7 +64,7 @@ public final class Slice
         implements Comparable<Slice>
 {
     private static final int INSTANCE_SIZE = instanceSize(Slice.class);
-    private static final Object COMPACT = new byte[0];
+    private static final byte[] COMPACT = new byte[0];
     private static final Object NOT_COMPACT = null;
     private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0);
 
@@ -121,8 +121,8 @@ public final class Slice
      */
     Slice()
     {
-        this.base = null;
-        this.address = 0;
+        this.base = COMPACT;
+        this.address = ARRAY_BYTE_BASE_OFFSET;
         this.size = 0;
         this.retainedSize = INSTANCE_SIZE;
         this.reference = COMPACT;

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -49,10 +49,15 @@ import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_BOOLEAN_INDEX_SCALE;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+import static sun.misc.Unsafe.ARRAY_DOUBLE_BASE_OFFSET;
 import static sun.misc.Unsafe.ARRAY_DOUBLE_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_FLOAT_BASE_OFFSET;
 import static sun.misc.Unsafe.ARRAY_FLOAT_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_INT_BASE_OFFSET;
 import static sun.misc.Unsafe.ARRAY_INT_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_LONG_BASE_OFFSET;
 import static sun.misc.Unsafe.ARRAY_LONG_INDEX_SCALE;
+import static sun.misc.Unsafe.ARRAY_SHORT_BASE_OFFSET;
 import static sun.misc.Unsafe.ARRAY_SHORT_INDEX_SCALE;
 
 public final class Slice
@@ -661,6 +666,246 @@ public final class Slice
     }
 
     /**
+     * Returns a copy of this buffer as a short array.
+     *
+     * @param index the absolute index to start at
+     * @param length the number of shorts to return
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less then {@code 0},
+     * or if the specified {@code index + length} is greater than {@code this.length()}
+     */
+    public short[] getShorts(int index, int length)
+    {
+        short[] shorts = new short[length];
+        getShorts(index, shorts, 0, length);
+        return shorts;
+    }
+
+    /**
+     * Transfers portion of data from this slice into the specified destination starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0}, or
+     * if {@code index + destination.length} is greater than {@code this.length()}
+     */
+    public void getShorts(int index, short[] destination)
+    {
+        getShorts(index, destination, 0, destination.length);
+    }
+
+    /**
+     * Transfers portion of data from this slice into the specified destination starting at
+     * the specified absolute {@code index}.
+     *
+     * @param destinationIndex the first index of the destination
+     * @param length the number of shorts to transfer
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * if the specified {@code destinationIndex} is less than {@code 0},
+     * if {@code index + length} is greater than
+     * {@code this.length()}, or
+     * if {@code destinationIndex + length} is greater than
+     * {@code destination.length}
+     */
+    public void getShorts(int index, short[] destination, int destinationIndex, int length)
+    {
+        checkFromIndexSize(index, length * Short.BYTES, length());
+        checkFromIndexSize(destinationIndex, length, destination.length);
+
+        copyMemory(base, address + index, destination, ARRAY_SHORT_BASE_OFFSET + ((long) destinationIndex * Short.BYTES), length * Short.BYTES);
+    }
+
+    /**
+     * Returns a copy of this buffer as a int array.
+     *
+     * @param index the absolute index to start at
+     * @param length the number of ints to return
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less then {@code 0},
+     * or if the specified {@code index + length} is greater than {@code this.length()}
+     */
+    public int[] getInts(int index, int length)
+    {
+        int[] ints = new int[length];
+        getInts(index, ints, 0, length);
+        return ints;
+    }
+
+    /**
+     * Transfers portion of data from this slice into the specified destination starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0}, or
+     * if {@code index + destination.length} is greater than {@code this.length()}
+     */
+    public void getInts(int index, int[] destination)
+    {
+        getInts(index, destination, 0, destination.length);
+    }
+
+    /**
+     * Transfers portion of data from this slice into the specified destination starting at
+     * the specified absolute {@code index}.
+     *
+     * @param destinationIndex the first index of the destination
+     * @param length the number of ints to transfer
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * if the specified {@code destinationIndex} is less than {@code 0},
+     * if {@code index + length} is greater than
+     * {@code this.length()}, or
+     * if {@code destinationIndex + length} is greater than
+     * {@code destination.length}
+     */
+    public void getInts(int index, int[] destination, int destinationIndex, int length)
+    {
+        checkFromIndexSize(index, length * Integer.BYTES, length());
+        checkFromIndexSize(destinationIndex, length, destination.length);
+
+        copyMemory(base, address + index, destination, ARRAY_INT_BASE_OFFSET + ((long) destinationIndex * Integer.BYTES), length * Integer.BYTES);
+    }
+
+    /**
+     * Returns a copy of this buffer as a long array.
+     *
+     * @param index the absolute index to start at
+     * @param length the number of longs to return
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less then {@code 0},
+     * or if the specified {@code index + length} is greater than {@code this.length()}
+     */
+    public long[] getLongs(int index, int length)
+    {
+        long[] longs = new long[length];
+        getLongs(index, longs, 0, length);
+        return longs;
+    }
+
+    /**
+     * Transfers portion of data from this slice into the specified destination starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0}, or
+     * if {@code index + destination.length} is greater than {@code this.length()}
+     */
+    public void getLongs(int index, long[] destination)
+    {
+        getLongs(index, destination, 0, destination.length);
+    }
+
+    /**
+     * Transfers portion of data from this slice into the specified destination starting at
+     * the specified absolute {@code index}.
+     *
+     * @param destinationIndex the first index of the destination
+     * @param length the number of longs to transfer
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * if the specified {@code destinationIndex} is less than {@code 0},
+     * if {@code index + length} is greater than
+     * {@code this.length()}, or
+     * if {@code destinationIndex + length} is greater than
+     * {@code destination.length}
+     */
+    public void getLongs(int index, long[] destination, int destinationIndex, int length)
+    {
+        checkFromIndexSize(index, length * Long.BYTES, length());
+        checkFromIndexSize(destinationIndex, length, destination.length);
+
+        copyMemory(base, address + index, destination, ARRAY_LONG_BASE_OFFSET + ((long) destinationIndex * Long.BYTES), length * Long.BYTES);
+    }
+
+    /**
+     * Returns a copy of this buffer as a float array.
+     *
+     * @param index the absolute index to start at
+     * @param length the number of floats to return
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less then {@code 0},
+     * or if the specified {@code index + length} is greater than {@code this.length()}
+     */
+    public float[] getFloats(int index, int length)
+    {
+        float[] floats = new float[length];
+        getFloats(index, floats, 0, length);
+        return floats;
+    }
+
+    /**
+     * Transfers portion of data from this slice into the specified destination starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0}, or
+     * if {@code index + destination.length} is greater than {@code this.length()}
+     */
+    public void getFloats(int index, float[] destination)
+    {
+        getFloats(index, destination, 0, destination.length);
+    }
+
+    /**
+     * Transfers portion of data from this slice into the specified destination starting at
+     * the specified absolute {@code index}.
+     *
+     * @param destinationIndex the first index of the destination
+     * @param length the number of floats to transfer
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * if the specified {@code destinationIndex} is less than {@code 0},
+     * if {@code index + length} is greater than
+     * {@code this.length()}, or
+     * if {@code destinationIndex + length} is greater than
+     * {@code destination.length}
+     */
+    public void getFloats(int index, float[] destination, int destinationIndex, int length)
+    {
+        checkFromIndexSize(index, length * Float.BYTES, length());
+        checkFromIndexSize(destinationIndex, length, destination.length);
+
+        copyMemory(base, address + index, destination, ARRAY_FLOAT_BASE_OFFSET + ((long) destinationIndex * Float.BYTES), length * Float.BYTES);
+    }
+
+    /**
+     * Returns a copy of this buffer as a double array.
+     *
+     * @param index the absolute index to start at
+     * @param length the number of doubles to return
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less then {@code 0},
+     * or if the specified {@code index + length} is greater than {@code this.length()}
+     */
+    public double[] getDoubles(int index, int length)
+    {
+        double[] doubles = new double[length];
+        getDoubles(index, doubles, 0, length);
+        return doubles;
+    }
+
+    /**
+     * Transfers portion of data from this slice into the specified destination starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0}, or
+     * if {@code index + destination.length} is greater than {@code this.length()}
+     */
+    public void getDoubles(int index, double[] destination)
+    {
+        getDoubles(index, destination, 0, destination.length);
+    }
+
+    /**
+     * Transfers portion of data from this slice into the specified destination starting at
+     * the specified absolute {@code index}.
+     *
+     * @param destinationIndex the first index of the destination
+     * @param length the number of doubles to transfer
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * if the specified {@code destinationIndex} is less than {@code 0},
+     * if {@code index + length} is greater than
+     * {@code this.length()}, or
+     * if {@code destinationIndex + length} is greater than
+     * {@code destination.length}
+     */
+    public void getDoubles(int index, double[] destination, int destinationIndex, int length)
+    {
+        checkFromIndexSize(index, length * Double.BYTES, length());
+        checkFromIndexSize(destinationIndex, length, destination.length);
+
+        copyMemory(base, address + index, destination, ARRAY_DOUBLE_BASE_OFFSET + ((long) destinationIndex * Double.BYTES), length * Double.BYTES);
+    }
+
+    /**
      * Sets the specified byte at the specified absolute {@code index} in this
      * buffer.  The 24 high-order bits of the specified value are ignored.
      *
@@ -857,6 +1102,151 @@ public final class Slice
             length -= bytesRead;
             index += bytesRead;
         }
+    }
+
+    /**
+     * Transfers data from the specified slice into this buffer starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0}, or
+     * if {@code index + source.length} is greater than {@code this.length()}
+     */
+    public void setShorts(int index, short[] source)
+    {
+        setShorts(index, source, 0, source.length);
+    }
+
+    /**
+     * Transfers data from the specified array into this buffer starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * if the specified {@code sourceIndex} is less than {@code 0},
+     * if {@code index + length} is greater than
+     * {@code this.length()}, or
+     * if {@code sourceIndex + length} is greater than {@code source.length}
+     */
+    public void setShorts(int index, short[] source, int sourceIndex, int length)
+    {
+        checkFromIndexSize(index, length, length());
+        checkFromIndexSize(sourceIndex, length, source.length);
+        copyMemory(source, ARRAY_SHORT_BASE_OFFSET + ((long) sourceIndex * Short.BYTES), base, address + index, length * Short.BYTES);
+    }
+
+    /**
+     * Transfers data from the specified slice into this buffer starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0}, or
+     * if {@code index + source.length} is greater than {@code this.length()}
+     */
+    public void setInts(int index, int[] source)
+    {
+        setInts(index, source, 0, source.length);
+    }
+
+    /**
+     * Transfers data from the specified array into this buffer starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * if the specified {@code sourceIndex} is less than {@code 0},
+     * if {@code index + length} is greater than
+     * {@code this.length()}, or
+     * if {@code sourceIndex + length} is greater than {@code source.length}
+     */
+    public void setInts(int index, int[] source, int sourceIndex, int length)
+    {
+        checkFromIndexSize(index, length, length());
+        checkFromIndexSize(sourceIndex, length, source.length);
+        copyMemory(source, ARRAY_INT_BASE_OFFSET + ((long) sourceIndex * Integer.BYTES), base, address + index, length * Integer.BYTES);
+    }
+
+    /**
+     * Transfers data from the specified slice into this buffer starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0}, or
+     * if {@code index + source.length} is greater than {@code this.length()}
+     */
+    public void setLongs(int index, long[] source)
+    {
+        setLongs(index, source, 0, source.length);
+    }
+
+    /**
+     * Transfers data from the specified array into this buffer starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * if the specified {@code sourceIndex} is less than {@code 0},
+     * if {@code index + length} is greater than
+     * {@code this.length()}, or
+     * if {@code sourceIndex + length} is greater than {@code source.length}
+     */
+    public void setLongs(int index, long[] source, int sourceIndex, int length)
+    {
+        checkFromIndexSize(index, length, length());
+        checkFromIndexSize(sourceIndex, length, source.length);
+        copyMemory(source, ARRAY_LONG_BASE_OFFSET + ((long) sourceIndex * Long.BYTES), base, address + index, length * Long.BYTES);
+    }
+
+    /**
+     * Transfers data from the specified slice into this buffer starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0}, or
+     * if {@code index + source.length} is greater than {@code this.length()}
+     */
+    public void setFloats(int index, float[] source)
+    {
+        setFloats(index, source, 0, source.length);
+    }
+
+    /**
+     * Transfers data from the specified array into this buffer starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * if the specified {@code sourceIndex} is less than {@code 0},
+     * if {@code index + length} is greater than
+     * {@code this.length()}, or
+     * if {@code sourceIndex + length} is greater than {@code source.length}
+     */
+    public void setFloats(int index, float[] source, int sourceIndex, int length)
+    {
+        checkFromIndexSize(index, length, length());
+        checkFromIndexSize(sourceIndex, length, source.length);
+        copyMemory(source, ARRAY_FLOAT_BASE_OFFSET + ((long) sourceIndex * Float.BYTES), base, address + index, length * Float.BYTES);
+    }
+
+    /**
+     * Transfers data from the specified slice into this buffer starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0}, or
+     * if {@code index + source.length} is greater than {@code this.length()}
+     */
+    public void setDoubles(int index, double[] source)
+    {
+        setDoubles(index, source, 0, source.length);
+    }
+
+    /**
+     * Transfers data from the specified array into this buffer starting at
+     * the specified absolute {@code index}.
+     *
+     * @throws IndexOutOfBoundsException if the specified {@code index} is less than {@code 0},
+     * if the specified {@code sourceIndex} is less than {@code 0},
+     * if {@code index + length} is greater than
+     * {@code this.length()}, or
+     * if {@code sourceIndex + length} is greater than {@code source.length}
+     */
+    public void setDoubles(int index, double[] source, int sourceIndex, int length)
+    {
+        checkFromIndexSize(index, length, length());
+        checkFromIndexSize(sourceIndex, length, source.length);
+        copyMemory(source, ARRAY_DOUBLE_BASE_OFFSET + ((long) sourceIndex * Double.BYTES), base, address + index, length * Double.BYTES);
     }
 
     /**

--- a/src/main/java/io/airlift/slice/SliceInput.java
+++ b/src/main/java/io/airlift/slice/SliceInput.java
@@ -206,6 +206,131 @@ public abstract class SliceInput
 
     /**
      * Transfers this buffer's data to the specified destination starting at
+     * the current {@code position} and increases the {@code position}
+     * by the number of the transferred shorts (= {@code dst.length}).
+     *
+     * @throws IndexOutOfBoundsException if {@code dst.length} is greater than {@code this.available()}
+     */
+    public final void readShorts(short[] destination)
+    {
+        readShorts(destination, 0, destination.length);
+    }
+
+    /**
+     * Transfers this buffer's data to the specified destination starting at
+     * the current {@code position} and increases the {@code position}
+     * by the number of the transferred shorts (= {@code length}).
+     *
+     * @param destinationIndex the first index of the destination
+     * @param length the number of shorts to transfer
+     * @throws IndexOutOfBoundsException if the specified {@code destinationIndex} is less than {@code 0},
+     * if {@code length} is greater than {@code this.available()}, or
+     * if {@code destinationIndex + length} is greater than {@code destination.length}
+     */
+    public abstract void readShorts(short[] destination, int destinationIndex, int length);
+
+    /**
+     * Transfers this buffer's data to the specified destination starting at
+     * the current {@code position} and increases the {@code position}
+     * by the number of the transferred ints (= {@code dst.length}).
+     *
+     * @throws IndexOutOfBoundsException if {@code dst.length} is greater than {@code this.available()}
+     */
+    public final void readInts(int[] destination)
+    {
+        readInts(destination, 0, destination.length);
+    }
+
+    /**
+     * Transfers this buffer's data to the specified destination starting at
+     * the current {@code position} and increases the {@code position}
+     * by the number of the transferred ints (= {@code length}).
+     *
+     * @param destinationIndex the first index of the destination
+     * @param length the number of ints to transfer
+     * @throws IndexOutOfBoundsException if the specified {@code destinationIndex} is less than {@code 0},
+     * if {@code length} is greater than {@code this.available()}, or
+     * if {@code destinationIndex + length} is greater than {@code destination.length}
+     */
+    public abstract void readInts(int[] destination, int destinationIndex, int length);
+
+    /**
+     * Transfers this buffer's data to the specified destination starting at
+     * the current {@code position} and increases the {@code position}
+     * by the number of the transferred longs (= {@code dst.length}).
+     *
+     * @throws IndexOutOfBoundsException if {@code dst.length} is greater than {@code this.available()}
+     */
+    public final void readLongs(long[] destination)
+    {
+        readLongs(destination, 0, destination.length);
+    }
+
+    /**
+     * Transfers this buffer's data to the specified destination starting at
+     * the current {@code position} and increases the {@code position}
+     * by the number of the transferred longs (= {@code length}).
+     *
+     * @param destinationIndex the first index of the destination
+     * @param length the number of longs to transfer
+     * @throws IndexOutOfBoundsException if the specified {@code destinationIndex} is less than {@code 0},
+     * if {@code length} is greater than {@code this.available()}, or
+     * if {@code destinationIndex + length} is greater than {@code destination.length}
+     */
+    public abstract void readLongs(long[] destination, int destinationIndex, int length);
+
+    /**
+     * Transfers this buffer's data to the specified destination starting at
+     * the current {@code position} and increases the {@code position}
+     * by the number of the transferred floats (= {@code dst.length}).
+     *
+     * @throws IndexOutOfBoundsException if {@code dst.length} is greater than {@code this.available()}
+     */
+    public final void readFloats(float[] destination)
+    {
+        readFloats(destination, 0, destination.length);
+    }
+
+    /**
+     * Transfers this buffer's data to the specified destination starting at
+     * the current {@code position} and increases the {@code position}
+     * by the number of the transferred floats (= {@code length}).
+     *
+     * @param destinationIndex the first index of the destination
+     * @param length the number of floats to transfer
+     * @throws IndexOutOfBoundsException if the specified {@code destinationIndex} is less than {@code 0},
+     * if {@code length} is greater than {@code this.available()}, or
+     * if {@code destinationIndex + length} is greater than {@code destination.length}
+     */
+    public abstract void readFloats(float[] destination, int destinationIndex, int length);
+
+    /**
+     * Transfers this buffer's data to the specified destination starting at
+     * the current {@code position} and increases the {@code position}
+     * by the number of the transferred doubles (= {@code dst.length}).
+     *
+     * @throws IndexOutOfBoundsException if {@code dst.length} is greater than {@code this.available()}
+     */
+    public final void readDoubles(double[] destination)
+    {
+        readDoubles(destination, 0, destination.length);
+    }
+
+    /**
+     * Transfers this buffer's data to the specified destination starting at
+     * the current {@code position} and increases the {@code position}
+     * by the number of the transferred doubles (= {@code length}).
+     *
+     * @param destinationIndex the first index of the destination
+     * @param length the number of doubles to transfer
+     * @throws IndexOutOfBoundsException if the specified {@code destinationIndex} is less than {@code 0},
+     * if {@code length} is greater than {@code this.available()}, or
+     * if {@code destinationIndex + length} is greater than {@code destination.length}
+     */
+    public abstract void readDoubles(double[] destination, int destinationIndex, int length);
+
+    /**
+     * Transfers this buffer's data to the specified destination starting at
      * the current {@code position} until the destination becomes
      * non-writable, and increases the {@code position} by the number of the
      * transferred bytes.  This method is basically same with

--- a/src/main/java/io/airlift/slice/SliceOutput.java
+++ b/src/main/java/io/airlift/slice/SliceOutput.java
@@ -189,6 +189,106 @@ public abstract class SliceOutput
     public abstract void writeBytes(byte[] source, int sourceIndex, int length);
 
     /**
+     * Transfers the specified source array's data to this buffer starting at
+     * the current {@code writerIndex} and increases the {@code writerIndex}
+     * by the number of the transferred shorts.
+     */
+    public void writeShorts(short[] source)
+    {
+        writeShorts(source, 0, source.length);
+    }
+
+    /**
+     * Transfers the specified source array's data to this buffer starting at
+     * the current {@code writerIndex} and increases the {@code writerIndex}
+     * by the number of the transferred shorts.
+     *
+     * @param sourceIndex the first index of the source
+     * @param length the number of shorts to transfer
+     */
+    public abstract void writeShorts(short[] source, int sourceIndex, int length);
+
+    /**
+     * Transfers the specified source array's data to this buffer starting at
+     * the current {@code writerIndex} and increases the {@code writerIndex}
+     * by the number of the transferred ints.
+     */
+    public void writeInts(int[] source)
+    {
+        writeInts(source, 0, source.length);
+    }
+
+    /**
+     * Transfers the specified source array's data to this buffer starting at
+     * the current {@code writerIndex} and increases the {@code writerIndex}
+     * by the number of the transferred ints.
+     *
+     * @param sourceIndex the first index of the source
+     * @param length the number of ints to transfer
+     */
+    public abstract void writeInts(int[] source, int sourceIndex, int length);
+
+    /**
+     * Transfers the specified source array's data to this buffer starting at
+     * the current {@code writerIndex} and increases the {@code writerIndex}
+     * by the number of the transferred longs.
+     */
+    public void writeLongs(long[] source)
+    {
+        writeLongs(source, 0, source.length);
+    }
+
+    /**
+     * Transfers the specified source array's data to this buffer starting at
+     * the current {@code writerIndex} and increases the {@code writerIndex}
+     * by the number of the transferred longs.
+     *
+     * @param sourceIndex the first index of the source
+     * @param length the number of longs to transfer
+     */
+    public abstract void writeLongs(long[] source, int sourceIndex, int length);
+
+    /**
+     * Transfers the specified source array's data to this buffer starting at
+     * the current {@code writerIndex} and increases the {@code writerIndex}
+     * by the number of the transferred floats.
+     */
+    public void writeFloats(float[] source)
+    {
+        writeFloats(source, 0, source.length);
+    }
+
+    /**
+     * Transfers the specified source array's data to this buffer starting at
+     * the current {@code writerIndex} and increases the {@code writerIndex}
+     * by the number of the transferred floats.
+     *
+     * @param sourceIndex the first index of the source
+     * @param length the number of floats to transfer
+     */
+    public abstract void writeFloats(float[] source, int sourceIndex, int length);
+
+    /**
+     * Transfers the specified source array's data to this buffer starting at
+     * the current {@code writerIndex} and increases the {@code writerIndex}
+     * by the number of the transferred doubles.
+     */
+    public void writeDoubles(double[] source)
+    {
+        writeDoubles(source, 0, source.length);
+    }
+
+    /**
+     * Transfers the specified source array's data to this buffer starting at
+     * the current {@code writerIndex} and increases the {@code writerIndex}
+     * by the number of the transferred doubles.
+     *
+     * @param sourceIndex the first index of the source
+     * @param length the number of doubles to transfer
+     */
+    public abstract void writeDoubles(double[] source, int sourceIndex, int length);
+
+    /**
      * Transfers the content of the specified stream to this buffer
      * starting at the current {@code writerIndex} and increases the
      * {@code writerIndex} by the number of the transferred bytes.
@@ -276,6 +376,66 @@ public abstract class SliceOutput
     public abstract SliceOutput appendBytes(byte[] source, int sourceIndex, int length);
 
     public abstract SliceOutput appendBytes(byte[] source);
+
+    public SliceOutput appendShorts(short[] source)
+    {
+        writeShorts(source);
+        return this;
+    }
+
+    public SliceOutput appendShorts(short[] source, int sourceIndex, int length)
+    {
+        writeShorts(source, sourceIndex, length);
+        return this;
+    }
+
+    public SliceOutput appendInts(int[] source)
+    {
+        writeInts(source);
+        return this;
+    }
+
+    public SliceOutput appendInts(int[] source, int sourceIndex, int length)
+    {
+        writeInts(source, sourceIndex, length);
+        return this;
+    }
+
+    public SliceOutput appendLongs(long[] source)
+    {
+        writeLongs(source);
+        return this;
+    }
+
+    public SliceOutput appendLongs(long[] source, int sourceIndex, int length)
+    {
+        writeLongs(source, sourceIndex, length);
+        return this;
+    }
+
+    public SliceOutput appendFloats(float[] source)
+    {
+        writeFloats(source);
+        return this;
+    }
+
+    public SliceOutput appendFloats(float[] source, int sourceIndex, int length)
+    {
+        writeFloats(source, sourceIndex, length);
+        return this;
+    }
+
+    public SliceOutput appendDoubles(double[] source)
+    {
+        writeDoubles(source);
+        return this;
+    }
+
+    public SliceOutput appendDoubles(double[] source, int sourceIndex, int length)
+    {
+        writeDoubles(source, sourceIndex, length);
+        return this;
+    }
 
     public abstract SliceOutput appendBytes(Slice slice);
 

--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -89,6 +89,7 @@ public final class Slices
         return new Slice(new byte[capacity]);
     }
 
+    @Deprecated(forRemoval = true)
     public static Slice allocateDirect(int capacity)
     {
         if (capacity == 0) {
@@ -115,6 +116,7 @@ public final class Slices
     /**
      * Wrap the visible portion of a {@link java.nio.ByteBuffer}.
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedBuffer(ByteBuffer buffer)
     {
         if (buffer.isDirect()) {
@@ -186,6 +188,7 @@ public final class Slices
     /**
      * Creates a slice over the specified array.
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedShortArray(short... array)
     {
         return wrappedShortArray(array, 0, array.length);
@@ -197,6 +200,7 @@ public final class Slices
      * @param offset the array position at which the slice begins
      * @param length the number of array positions to include in the slice
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedShortArray(short[] array, int offset, int length)
     {
         if (length == 0) {
@@ -208,6 +212,7 @@ public final class Slices
     /**
      * Creates a slice over the specified array.
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedIntArray(int... array)
     {
         return wrappedIntArray(array, 0, array.length);
@@ -219,6 +224,7 @@ public final class Slices
      * @param offset the array position at which the slice begins
      * @param length the number of array positions to include in the slice
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedIntArray(int[] array, int offset, int length)
     {
         if (length == 0) {
@@ -230,6 +236,7 @@ public final class Slices
     /**
      * Creates a slice over the specified array.
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedLongArray(long... array)
     {
         return wrappedLongArray(array, 0, array.length);
@@ -241,6 +248,7 @@ public final class Slices
      * @param offset the array position at which the slice begins
      * @param length the number of array positions to include in the slice
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedLongArray(long[] array, int offset, int length)
     {
         if (length == 0) {
@@ -252,6 +260,7 @@ public final class Slices
     /**
      * Creates a slice over the specified array.
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedFloatArray(float... array)
     {
         return wrappedFloatArray(array, 0, array.length);
@@ -263,6 +272,7 @@ public final class Slices
      * @param offset the array position at which the slice begins
      * @param length the number of array positions to include in the slice
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedFloatArray(float[] array, int offset, int length)
     {
         if (length == 0) {
@@ -274,6 +284,7 @@ public final class Slices
     /**
      * Creates a slice over the specified array.
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedDoubleArray(double... array)
     {
         return wrappedDoubleArray(array, 0, array.length);
@@ -285,6 +296,7 @@ public final class Slices
      * @param offset the array position at which the slice begins
      * @param length the number of array positions to include in the slice
      */
+    @Deprecated(forRemoval = true)
     public static Slice wrappedDoubleArray(double[] array, int offset, int length)
     {
         if (length == 0) {
@@ -306,6 +318,7 @@ public final class Slices
         return copiedBuffer(string, UTF_8);
     }
 
+    @Deprecated(forRemoval = true)
     public static Slice mapFileReadOnly(File file)
             throws IOException
     {

--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -122,11 +122,16 @@ public final class Slices
             return new Slice(null, address + buffer.position(), buffer.remaining(), buffer.capacity(), buffer);
         }
 
-        if (buffer.hasArray()) {
-            return new Slice(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
+        return wrappedHeapBuffer(buffer);
+    }
+
+    public static Slice wrappedHeapBuffer(ByteBuffer buffer)
+    {
+        if (!buffer.hasArray()) {
+            throw new IllegalArgumentException("cannot wrap " + buffer.getClass().getName());
         }
 
-        throw new IllegalArgumentException("cannot wrap " + buffer.getClass().getName());
+        return new Slice(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
     }
 
     /**

--- a/src/main/java/io/airlift/slice/UnsafeSliceFactory.java
+++ b/src/main/java/io/airlift/slice/UnsafeSliceFactory.java
@@ -16,6 +16,7 @@ package io.airlift.slice;
 /**
  * A slice factory for creating unsafe slices
  */
+@Deprecated(forRemoval = true)
 public class UnsafeSliceFactory
 {
     private static final UnsafeSliceFactory INSTANCE = new UnsafeSliceFactory();

--- a/src/test/java/io/airlift/slice/AbstractSliceInputTest.java
+++ b/src/test/java/io/airlift/slice/AbstractSliceInputTest.java
@@ -245,6 +245,141 @@ public abstract class AbstractSliceInputTest
     }
 
     @Test
+    public void testReadShorts()
+    {
+        testSliceInput(new SliceInputTester(SIZE_OF_SHORT * 17)
+        {
+            @Override
+            public void loadValue(SliceOutput output, int valueIndex)
+            {
+                short[] shorts = new short[23];
+                for (int i = 0; i < shorts.length; i++) {
+                    shorts[i] = (short) (i * 37 + valueIndex);
+                }
+                output.writeShorts(shorts, 3, 17);
+            }
+
+            @Override
+            public void verifyValue(SliceInput input, int valueIndex)
+            {
+                short[] shorts = new short[27];
+                input.readShorts(shorts, 5, 17);
+                for (int i = 0; i < 17; i++) {
+                    assertEquals(shorts[i + 5], (short) ((i + 3) * 37 + valueIndex));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testReadInts()
+    {
+        testSliceInput(new SliceInputTester(SIZE_OF_INT * 17)
+        {
+            @Override
+            public void loadValue(SliceOutput output, int valueIndex)
+            {
+                int[] ints = new int[23];
+                for (int i = 0; i < ints.length; i++) {
+                    ints[i] = (int) (i * 37 + valueIndex);
+                }
+                output.writeInts(ints, 3, 17);
+            }
+
+            @Override
+            public void verifyValue(SliceInput input, int valueIndex)
+            {
+                int[] ints = new int[27];
+                input.readInts(ints, 5, 17);
+                for (int i = 0; i < 17; i++) {
+                    assertEquals(ints[i + 5], (int) ((i + 3) * 37 + valueIndex));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testReadLongs()
+    {
+        testSliceInput(new SliceInputTester(SIZE_OF_LONG * 17)
+        {
+            @Override
+            public void loadValue(SliceOutput output, int valueIndex)
+            {
+                long[] longs = new long[23];
+                for (int i = 0; i < longs.length; i++) {
+                    longs[i] = (long) (i * 37 + valueIndex);
+                }
+                output.writeLongs(longs, 3, 17);
+            }
+
+            @Override
+            public void verifyValue(SliceInput input, int valueIndex)
+            {
+                long[] longs = new long[27];
+                input.readLongs(longs, 5, 17);
+                for (int i = 0; i < 17; i++) {
+                    assertEquals(longs[i + 5], (long) ((i + 3) * 37 + valueIndex));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testReadFloats()
+    {
+        testSliceInput(new SliceInputTester(SIZE_OF_FLOAT * 17)
+        {
+            @Override
+            public void loadValue(SliceOutput output, int valueIndex)
+            {
+                float[] floats = new float[23];
+                for (int i = 0; i < floats.length; i++) {
+                    floats[i] = (float) (i * 37 + valueIndex);
+                }
+                output.writeFloats(floats, 3, 17);
+            }
+
+            @Override
+            public void verifyValue(SliceInput input, int valueIndex)
+            {
+                float[] floats = new float[27];
+                input.readFloats(floats, 5, 17);
+                for (int i = 0; i < 17; i++) {
+                    assertEquals(floats[i + 5], (float) ((i + 3) * 37 + valueIndex));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testReadDoubles()
+    {
+        testSliceInput(new SliceInputTester(SIZE_OF_DOUBLE * 17)
+        {
+            @Override
+            public void loadValue(SliceOutput output, int valueIndex)
+            {
+                double[] doubles = new double[23];
+                for (int i = 0; i < doubles.length; i++) {
+                    doubles[i] = (double) (i * 37 + valueIndex);
+                }
+                output.writeDoubles(doubles, 3, 17);
+            }
+
+            @Override
+            public void verifyValue(SliceInput input, int valueIndex)
+            {
+                double[] doubles = new double[27];
+                input.readDoubles(doubles, 5, 17);
+                for (int i = 0; i < 17; i++) {
+                    assertEquals(doubles[i + 5], (double) ((i + 3) * 37 + valueIndex));
+                }
+            }
+        });
+    }
+
+    @Test
     public void testSkip()
     {
         for (int readSize : VARIABLE_READ_SIZES) {

--- a/src/test/java/io/airlift/slice/TestSlice.java
+++ b/src/test/java/io/airlift/slice/TestSlice.java
@@ -586,6 +586,266 @@ public class TestSlice
     }
 
     @Test
+    public void testShortsArray()
+    {
+        for (int size = 0; size < 100; size++) {
+            for (int index = 0; index < size; index++) {
+                assertShortsArray(allocate(size), index);
+            }
+        }
+    }
+
+    private static void assertShortsArray(Slice slice, int index)
+    {
+        // fill slice with FF
+        slice.fill((byte) 0xFF);
+
+        short[] value = new short[(slice.length() - index) / 2];
+        slice.getShorts(index, value);
+        for (short v : value) {
+            assertEquals(v, -1);
+        }
+        Arrays.fill(value, (short) -1);
+        assertEquals(slice.getShorts(index, value.length), value);
+
+        // set and get the value
+        value = new short[value.length / 2];
+        for (int i = 0; i < value.length; i++) {
+            value[i] = (short) i;
+        }
+        slice.setShorts(index, value);
+        assertEquals(slice.getShorts(index, value.length), value);
+
+        for (int length = 0; length < value.length; length++) {
+            slice.fill((byte) 0xFF);
+            slice.setShorts(index, value, 0, length);
+            assertEquals(slice.getShorts(index, length), Arrays.copyOf(value, length));
+        }
+
+        try {
+            slice.setShorts(slice.length() - 1, new short[10]);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException ignored) {
+        }
+
+        try {
+            slice.setShorts(slice.length() - 1, new short[20], 1, 10);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException ignored) {
+        }
+    }
+
+    @Test
+    public void testIntsArray()
+    {
+        for (int size = 0; size < 100; size++) {
+            for (int index = 0; index < size; index++) {
+                assertIntsArray(allocate(size), index);
+            }
+        }
+    }
+
+    private static void assertIntsArray(Slice slice, int index)
+    {
+        // fill slice with FF
+        slice.fill((byte) 0xFF);
+
+        int[] value = new int[(slice.length() - index) / 4];
+        slice.getInts(index, value);
+        for (int v : value) {
+            assertEquals(v, -1);
+        }
+        Arrays.fill(value, -1);
+        assertEquals(slice.getInts(index, value.length), value);
+
+        // set and get the value
+        value = new int[value.length / 2];
+        for (int i = 0; i < value.length; i++) {
+            value[i] = i;
+        }
+        slice.setInts(index, value);
+        assertEquals(slice.getInts(index, value.length), value);
+
+        for (int length = 0; length < value.length; length++) {
+            slice.fill((byte) 0xFF);
+            slice.setInts(index, value, 0, length);
+            assertEquals(slice.getInts(index, length), Arrays.copyOf(value, length));
+        }
+
+        try {
+            slice.setInts(slice.length() - 1, new int[10]);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException ignored) {
+        }
+
+        try {
+            slice.setInts(slice.length() - 1, new int[20], 1, 10);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException ignored) {
+        }
+    }
+
+    @Test
+    public void testLongsArray()
+    {
+        for (int size = 0; size < 100; size++) {
+            for (int index = 0; index < size; index++) {
+                assertLongsArray(allocate(size), index);
+            }
+        }
+    }
+
+    private static void assertLongsArray(Slice slice, int index)
+    {
+        // fill slice with FF
+        slice.fill((byte) 0xFF);
+
+        long[] value = new long[(slice.length() - index) / 8];
+        slice.getLongs(index, value);
+        for (long v : value) {
+            assertEquals(v, -1);
+        }
+        Arrays.fill(value, -1L);
+        assertEquals(slice.getLongs(index, value.length), value);
+
+        // set and get the value
+        value = new long[value.length / 2];
+        for (int i = 0; i < value.length; i++) {
+            value[i] = i;
+        }
+        slice.setLongs(index, value);
+        assertEquals(slice.getLongs(index, value.length), value);
+
+        for (int length = 0; length < value.length; length++) {
+            slice.fill((byte) 0xFF);
+            slice.setLongs(index, value, 0, length);
+            assertEquals(slice.getLongs(index, length), Arrays.copyOf(value, length));
+        }
+
+        try {
+            slice.setLongs(slice.length() - 1, new long[10]);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException ignored) {
+        }
+
+        try {
+            slice.setLongs(slice.length() - 1, new long[20], 1, 10);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException ignored) {
+        }
+    }
+
+    @Test
+    public void testFloatsArray()
+    {
+        for (int size = 0; size < 100; size++) {
+            for (int index = 0; index < size; index++) {
+                assertFloatsArray(allocate(size), index);
+            }
+        }
+    }
+
+    private static void assertFloatsArray(Slice slice, int index)
+    {
+        // fill slice with FF
+        slice.fill((byte) 0xFF);
+
+        float[] value = new float[(slice.length() - index) / 4];
+        slice.getFloats(index, value);
+        for (float v : value) {
+            assertEquals(v, intBitsToFloat(-1));
+        }
+        Arrays.fill(value, intBitsToFloat(-1));
+        assertEquals(slice.getFloats(index, value.length), value);
+
+        // set and get the value
+        value = new float[value.length / 2];
+        for (int i = 0; i < value.length; i++) {
+            value[i] = i;
+        }
+        slice.setFloats(index, value);
+        assertEquals(slice.getFloats(index, value.length), value);
+
+        for (int length = 0; length < value.length; length++) {
+            slice.fill((byte) 0xFF);
+            slice.setFloats(index, value, 0, length);
+            assertEquals(slice.getFloats(index, length), Arrays.copyOf(value, length));
+        }
+
+        try {
+            slice.setFloats(slice.length() - 1, new float[10]);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException ignored) {
+        }
+
+        try {
+            slice.setFloats(slice.length() - 1, new float[20], 1, 10);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException ignored) {
+        }
+    }
+
+    @Test
+    public void testDoublesArray()
+    {
+        for (int size = 0; size < 100; size++) {
+            for (int index = 0; index < size; index++) {
+                assertDoublesArray(allocate(size), index);
+            }
+        }
+    }
+
+    private static void assertDoublesArray(Slice slice, int index)
+    {
+        // fill slice with FF
+        slice.fill((byte) 0xFF);
+
+        double[] value = new double[(slice.length() - index) / 8];
+        slice.getDoubles(index, value);
+        for (double v : value) {
+            assertEquals(v, longBitsToDouble(-1));
+        }
+        Arrays.fill(value, longBitsToDouble(-1));
+        assertEquals(slice.getDoubles(index, value.length), value);
+
+        // set and get the value
+        value = new double[value.length / 2];
+        for (int i = 0; i < value.length; i++) {
+            value[i] = i;
+        }
+        slice.setDoubles(index, value);
+        assertEquals(slice.getDoubles(index, value.length), value);
+
+        for (int length = 0; length < value.length; length++) {
+            slice.fill((byte) 0xFF);
+            slice.setDoubles(index, value, 0, length);
+            assertEquals(slice.getDoubles(index, length), Arrays.copyOf(value, length));
+        }
+
+        try {
+            slice.setDoubles(slice.length() - 1, new double[10]);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException ignored) {
+        }
+
+        try {
+            slice.setDoubles(slice.length() - 1, new double[20], 1, 10);
+            fail("expected IndexOutOfBoundsException");
+        }
+        catch (IndexOutOfBoundsException ignored) {
+        }
+    }
+
+    @Test
     public void testBytesSlice()
     {
         for (int size = 0; size < 100; size++) {

--- a/src/test/java/io/airlift/slice/TestSliceCompactFlag.java
+++ b/src/test/java/io/airlift/slice/TestSliceCompactFlag.java
@@ -130,17 +130,17 @@ public class TestSliceCompactFlag
 
         // test full buffer
         buffer.rewind();
-        Slice slice = Slices.wrappedBuffer(buffer);
+        Slice slice = Slices.wrappedHeapBuffer(buffer);
         assertCompact(slice);
 
         // test limited buffer
         buffer.position(10).limit(30);
-        slice = Slices.wrappedBuffer(buffer);
+        slice = Slices.wrappedHeapBuffer(buffer);
         assertNotCompact(slice);
 
         // test limited buffer after slicing
         buffer = buffer.slice();
-        slice = Slices.wrappedBuffer(buffer);
+        slice = Slices.wrappedHeapBuffer(buffer);
         assertNotCompact(slice);
     }
 

--- a/src/test/java/io/airlift/slice/TestSlices.java
+++ b/src/test/java/io/airlift/slice/TestSlices.java
@@ -34,6 +34,7 @@ import static io.airlift.slice.Slices.wrappedBooleanArray;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.airlift.slice.Slices.wrappedDoubleArray;
 import static io.airlift.slice.Slices.wrappedFloatArray;
+import static io.airlift.slice.Slices.wrappedHeapBuffer;
 import static io.airlift.slice.Slices.wrappedIntArray;
 import static io.airlift.slice.Slices.wrappedLongArray;
 import static io.airlift.slice.Slices.wrappedShortArray;
@@ -60,7 +61,7 @@ public class TestSlices
     public void testWrapHeapBufferRetainedSize()
     {
         ByteBuffer heapByteBuffer = ByteBuffer.allocate(50);
-        Slice slice = wrappedBuffer(heapByteBuffer);
+        Slice slice = wrappedHeapBuffer(heapByteBuffer);
         assertEquals(slice.getRetainedSize(), instanceSize(Slice.class) + sizeOf(heapByteBuffer.array()));
     }
 

--- a/src/test/java/io/airlift/slice/TestSlices.java
+++ b/src/test/java/io/airlift/slice/TestSlices.java
@@ -25,6 +25,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.airlift.slice.Slices.MAX_ARRAY_SIZE;
 import static io.airlift.slice.Slices.SLICE_ALLOC_THRESHOLD;
 import static io.airlift.slice.Slices.SLICE_ALLOW_SKEW;
@@ -45,6 +46,15 @@ import static org.testng.Assert.assertTrue;
 
 public class TestSlices
 {
+    @Test
+    public void testEmptySlice()
+    {
+        assertEquals(EMPTY_SLICE.length(), 0);
+        assertTrue(EMPTY_SLICE.hasByteArray());
+        assertEquals(EMPTY_SLICE.byteArray().length, 0);
+        assertEquals(EMPTY_SLICE.byteArrayOffset(), 0);
+    }
+
     @Test
     public void testWrapDirectBuffer()
     {


### PR DESCRIPTION
Deprecate support Slice backed by anything other than byte[]

Slices over other data types are rarely used and can hurt performance due to the megamorphic call sites.  Once the other variants are removed we can vastly simplify the Slice code and convert most of unsafe calls to use VarHandle.
