### PR TITLE
More slice cleanup

### DIFF
--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -50,7 +50,6 @@ public final class Slice
         implements Comparable<Slice>
 {
     private static final int INSTANCE_SIZE = instanceSize(Slice.class);
-    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
     private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0);
 
     private static final VarHandle SHORT_HANDLE = byteArrayViewVarHandle(short[].class, LITTLE_ENDIAN);
@@ -58,6 +57,9 @@ public final class Slice
     private static final VarHandle LONG_HANDLE = byteArrayViewVarHandle(long[].class, LITTLE_ENDIAN);
     private static final VarHandle FLOAT_HANDLE = byteArrayViewVarHandle(float[].class, LITTLE_ENDIAN);
     private static final VarHandle DOUBLE_HANDLE = byteArrayViewVarHandle(double[].class, LITTLE_ENDIAN);
+
+    // Do not move this field above the constants used in the empty constructor
+    static final Slice EMPTY_SLICE = new Slice();
 
     private final byte[] base;
 
@@ -76,11 +78,13 @@ public final class Slice
     private int hash;
 
     /**
-     * Creates an empty slice.
+     * This is only used to create the EMPTY_SLICE constant.
      */
-    Slice()
+    private Slice()
     {
-        this.base = EMPTY_BYTE_ARRAY;
+        // Since this is used to create a constant in this class, be careful to not use
+        // other uninitialized constants.
+        this.base = new byte[0];
         this.baseOffset = 0;
         this.size = 0;
         this.retainedSize = INSTANCE_SIZE;
@@ -92,6 +96,9 @@ public final class Slice
     Slice(byte[] base)
     {
         requireNonNull(base, "base is null");
+        if (base.length == 0) {
+            throw new IllegalArgumentException("Empty array");
+        }
         this.base = base;
         this.baseOffset = 0;
         this.size = base.length;
@@ -107,6 +114,9 @@ public final class Slice
     Slice(byte[] base, int offset, int length)
     {
         requireNonNull(base, "base is null");
+        if (base.length == 0) {
+            throw new IllegalArgumentException("Empty array");
+        }
         checkFromIndexSize(offset, length, base.length);
 
         this.base = base;
@@ -121,6 +131,9 @@ public final class Slice
     Slice(byte[] base, int baseOffset, int size, long retainedSize)
     {
         requireNonNull(base, "base is null");
+        if (base.length == 0) {
+            throw new IllegalArgumentException("Empty array");
+        }
         checkFromIndexSize(baseOffset, size, base.length);
 
         this.base = requireNonNull(base, "base is null");

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -1029,6 +1029,31 @@ public final class Slice
         return new Slice(base, baseOffset + index, length, retainedSize);
     }
 
+    /**
+     * Returns a copy of this buffer's sub-region. Modifying the content of
+     * the returned buffer does not affect this buffer, and vice versa.
+     */
+    public Slice copy()
+    {
+        if (size == 0) {
+            return Slices.EMPTY_SLICE;
+        }
+        return new Slice(Arrays.copyOfRange(base, baseOffset, baseOffset + size));
+    }
+
+    /**
+     * Returns a copy of the specified region. Modifying the content of
+     * the returned buffer does not affect this buffer, and vice versa.
+     */
+    public Slice copy(int index, int length)
+    {
+        checkFromIndexSize(index, length, size);
+        if (length == 0) {
+            return Slices.EMPTY_SLICE;
+        }
+        return new Slice(Arrays.copyOfRange(base, baseOffset + index, baseOffset + index + length));
+    }
+
     public int indexOfByte(int b)
     {
         checkArgument((b >> Byte.SIZE) == 0, "byte value out of range");

--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -27,7 +27,7 @@ public final class Slices
     /**
      * A slice with size {@code 0}.
      */
-    public static final Slice EMPTY_SLICE = new Slice();
+    public static final Slice EMPTY_SLICE = Slice.EMPTY_SLICE;
 
     // see java.util.ArrayList for an explanation
     static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;

--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -15,6 +15,8 @@ package io.airlift.slice;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -78,6 +80,27 @@ public final class Slices
             throw new SliceTooLargeException(format("Cannot allocate slice larger than %s bytes", MAX_ARRAY_SIZE));
         }
         return new Slice(new byte[capacity]);
+    }
+
+    /**
+     * Allocates a new slice containing random bytes from ThreadLocalRandom.
+     */
+    public static Slice random(int capacity)
+    {
+        // Note: this only exists because many static checkers do not allow passing ThreadLocalRandom to methods
+        Slice slice = allocate(capacity);
+        ThreadLocalRandom.current().nextBytes(slice.byteArray());
+        return slice;
+    }
+
+    /**
+     * Allocates a new slice containing random bytes.
+     */
+    public static Slice random(int capacity, Random random)
+    {
+        Slice slice = allocate(capacity);
+        random.nextBytes(slice.byteArray());
+        return slice;
     }
 
     public static Slice wrappedHeapBuffer(ByteBuffer buffer)

--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -18,7 +18,6 @@ import java.nio.charset.Charset;
 
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
 
 public final class Slices
@@ -79,21 +78,6 @@ public final class Slices
             throw new SliceTooLargeException(format("Cannot allocate slice larger than %s bytes", MAX_ARRAY_SIZE));
         }
         return new Slice(new byte[capacity]);
-    }
-
-    public static Slice copyOf(Slice slice)
-    {
-        return copyOf(slice, 0, slice.length());
-    }
-
-    public static Slice copyOf(Slice slice, int offset, int length)
-    {
-        checkFromIndexSize(offset, length, slice.length());
-
-        Slice copy = Slices.allocate(length);
-        copy.setBytes(0, slice, offset, length);
-
-        return copy;
     }
 
     public static Slice wrappedHeapBuffer(ByteBuffer buffer)

--- a/src/test/java/io/airlift/slice/BenchmarkData.java
+++ b/src/test/java/io/airlift/slice/BenchmarkData.java
@@ -18,8 +18,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
-import java.util.concurrent.ThreadLocalRandom;
-
 @State(Scope.Thread)
 public class BenchmarkData
 {
@@ -35,9 +33,8 @@ public class BenchmarkData
     @Setup
     public void setup()
     {
-        bytes = new byte[size];
-        ThreadLocalRandom.current().nextBytes(bytes);
-        slice = Slices.wrappedBuffer(bytes);
+        slice = Slices.random(size);
+        bytes = slice.byteArray();
     }
 
     public Slice getSlice()

--- a/src/test/java/io/airlift/slice/SliceUtf8Benchmark.java
+++ b/src/test/java/io/airlift/slice/SliceUtf8Benchmark.java
@@ -221,11 +221,11 @@ public class SliceUtf8Benchmark
         public void setup()
         {
             Slice whitespace = createRandomUtf8Slice(ascii ? ASCII_WHITESPACE : ALL_WHITESPACE, length + 1);
-            leftWhitespace = Slices.copyOf(whitespace);
+            leftWhitespace = whitespace.copy();
             leftWhitespace.setByte(leftWhitespace.length() - 1, 'X');
-            rightWhitespace = Slices.copyOf(whitespace);
+            rightWhitespace = whitespace.copy();
             rightWhitespace.setByte(0, 'X');
-            bothWhitespace = Slices.copyOf(whitespace);
+            bothWhitespace = whitespace.copy();
             bothWhitespace.setByte(length / 2, 'X');
         }
 

--- a/src/test/java/io/airlift/slice/TestMurmur3Hash128.java
+++ b/src/test/java/io/airlift/slice/TestMurmur3Hash128.java
@@ -27,10 +27,11 @@ public class TestMurmur3Hash128
     @RepeatedTest(100)
     public void testLessThan16Bytes()
     {
-        byte[] data = randomBytes(ThreadLocalRandom.current().nextInt(16));
+        int length = ThreadLocalRandom.current().nextInt(16);
+        Slice data = Slices.random(length);
 
-        HashCode expected = Hashing.murmur3_128().hashBytes(data);
-        Slice actual = Murmur3Hash128.hash(Slices.wrappedBuffer(data));
+        HashCode expected = Hashing.murmur3_128().hashBytes(data.byteArray());
+        Slice actual = Murmur3Hash128.hash(data);
 
         assertThat(actual.getBytes()).isEqualTo(expected.asBytes());
     }
@@ -38,10 +39,10 @@ public class TestMurmur3Hash128
     @RepeatedTest(100)
     public void testMoreThan16Bytes()
     {
-        byte[] data = randomBytes(131);
+        Slice data = Slices.random(131);
 
-        HashCode expected = Hashing.murmur3_128().hashBytes(data);
-        Slice actual = Murmur3Hash128.hash(Slices.wrappedBuffer(data));
+        HashCode expected = Hashing.murmur3_128().hashBytes(data.byteArray());
+        Slice actual = Murmur3Hash128.hash(data);
 
         assertThat(actual.getBytes()).isEqualTo(expected.asBytes());
     }
@@ -49,13 +50,13 @@ public class TestMurmur3Hash128
     @RepeatedTest(100)
     public void testOffsetAndLength()
     {
-        byte[] data = randomBytes(131);
+        Slice data = Slices.random(131);
 
         int offset = 13;
         int length = 55;
 
-        HashCode expected = Hashing.murmur3_128().hashBytes(data, offset, length);
-        Slice actual = Murmur3Hash128.hash(Slices.wrappedBuffer(data), offset, length);
+        HashCode expected = Hashing.murmur3_128().hashBytes(data.byteArray(), offset, length);
+        Slice actual = Murmur3Hash128.hash(data, offset, length);
 
         assertThat(actual.getBytes()).isEqualTo(expected.asBytes());
     }
@@ -63,12 +64,12 @@ public class TestMurmur3Hash128
     @RepeatedTest(100)
     public void testNonDefaultSeed()
     {
-        byte[] data = randomBytes(131);
+        Slice data = Slices.random(131);
 
         int seed = 123456789;
 
-        HashCode expected = Hashing.murmur3_128(seed).hashBytes(data);
-        Slice actual = Murmur3Hash128.hash(seed, Slices.wrappedBuffer(data), 0, data.length);
+        HashCode expected = Hashing.murmur3_128(seed).hashBytes(data.byteArray());
+        Slice actual = Murmur3Hash128.hash(seed, data, 0, data.length());
 
         assertThat(actual.getBytes()).isEqualTo(expected.asBytes());
     }
@@ -77,10 +78,10 @@ public class TestMurmur3Hash128
     public void testTail()
     {
         for (int i = 0; i < 16; i++) {
-            byte[] data = randomBytes(50 + i);
+            Slice data = Slices.random(50 + i);
 
-            HashCode expected = Hashing.murmur3_128().hashBytes(data);
-            Slice actual = Murmur3Hash128.hash(Slices.wrappedBuffer(data));
+            HashCode expected = Hashing.murmur3_128().hashBytes(data.byteArray());
+            Slice actual = Murmur3Hash128.hash(data);
 
             assertThat(actual.getBytes()).isEqualTo(expected.asBytes());
         }
@@ -89,10 +90,11 @@ public class TestMurmur3Hash128
     @RepeatedTest(100)
     public void testLessThan16Bytes64()
     {
-        byte[] data = randomBytes(ThreadLocalRandom.current().nextInt(16));
+        int length = ThreadLocalRandom.current().nextInt(16);
+        Slice data = Slices.random(length);
 
-        long expected = Murmur3Hash128.hash(Slices.wrappedBuffer(data)).getLong(0);
-        long actual = Murmur3Hash128.hash64(Slices.wrappedBuffer(data));
+        long expected = Murmur3Hash128.hash(data).getLong(0);
+        long actual = Murmur3Hash128.hash64(data);
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -100,10 +102,10 @@ public class TestMurmur3Hash128
     @RepeatedTest(100)
     public void testMoreThan16Bytes64()
     {
-        byte[] data = randomBytes(131);
+        Slice data = Slices.random(131);
 
-        long expected = Murmur3Hash128.hash(Slices.wrappedBuffer(data)).getLong(0);
-        long actual = Murmur3Hash128.hash64(Slices.wrappedBuffer(data));
+        long expected = Murmur3Hash128.hash(data).getLong(0);
+        long actual = Murmur3Hash128.hash64(data);
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -111,13 +113,13 @@ public class TestMurmur3Hash128
     @RepeatedTest(100)
     public void testOffsetAndLength64()
     {
-        byte[] data = randomBytes(131);
+        Slice data = Slices.random(131);
 
         int offset = 13;
         int length = 55;
 
-        long expected = Murmur3Hash128.hash(Slices.wrappedBuffer(data), offset, length).getLong(0);
-        long actual = Murmur3Hash128.hash64(Slices.wrappedBuffer(data), offset, length);
+        long expected = Murmur3Hash128.hash(data, offset, length).getLong(0);
+        long actual = Murmur3Hash128.hash64(data, offset, length);
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -125,12 +127,12 @@ public class TestMurmur3Hash128
     @RepeatedTest(100)
     public void testNonDefaultSeed64()
     {
-        byte[] data = randomBytes(131);
+        Slice data = Slices.random(131);
 
         int seed = 123456789;
 
-        long expected = Murmur3Hash128.hash(seed, Slices.wrappedBuffer(data), 0, data.length).getLong(0);
-        long actual = Murmur3Hash128.hash64(seed, Slices.wrappedBuffer(data), 0, data.length);
+        long expected = Murmur3Hash128.hash(seed, data, 0, data.length()).getLong(0);
+        long actual = Murmur3Hash128.hash64(seed, data, 0, data.length());
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -139,10 +141,10 @@ public class TestMurmur3Hash128
     public void testTail64()
     {
         for (int i = 0; i < 16; i++) {
-            byte[] data = randomBytes(50 + i);
+            Slice data = Slices.random(50 + i);
 
-            long expected = Murmur3Hash128.hash(Slices.wrappedBuffer(data)).getLong(0);
-            long actual = Murmur3Hash128.hash64(Slices.wrappedBuffer(data));
+            long expected = Murmur3Hash128.hash(data).getLong(0);
+            long actual = Murmur3Hash128.hash64(data);
 
             assertThat(actual).isEqualTo(expected);
         }
@@ -151,10 +153,11 @@ public class TestMurmur3Hash128
     @RepeatedTest(100)
     public void test64ReturnsMsb()
     {
-        byte[] data = randomBytes(ThreadLocalRandom.current().nextInt(200));
+        int length = ThreadLocalRandom.current().nextInt(200);
+        Slice data = Slices.random(length);
 
-        long expected = Murmur3Hash128.hash(Slices.wrappedBuffer(data)).getLong(0);
-        long actual = Murmur3Hash128.hash64(Slices.wrappedBuffer(data));
+        long expected = Murmur3Hash128.hash(data).getLong(0);
+        long actual = Murmur3Hash128.hash64(data);
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -169,12 +172,5 @@ public class TestMurmur3Hash128
         long expected = Murmur3Hash128.hash64(slice);
         long actual = Murmur3Hash128.hash64(value);
         assertThat(actual).isEqualTo(expected);
-    }
-
-    private static byte[] randomBytes(int length)
-    {
-        byte[] result = new byte[length];
-        ThreadLocalRandom.current().nextBytes(result);
-        return result;
     }
 }

--- a/src/test/java/io/airlift/slice/TestMurmur3Hash32.java
+++ b/src/test/java/io/airlift/slice/TestMurmur3Hash32.java
@@ -26,10 +26,11 @@ public class TestMurmur3Hash32
     @RepeatedTest(100)
     public void testLessThan4Bytes()
     {
-        byte[] data = randomBytes(ThreadLocalRandom.current().nextInt(4));
+        int length = ThreadLocalRandom.current().nextInt(4);
+        Slice data = Slices.random(length);
 
-        int expected = Hashing.murmur3_32_fixed().hashBytes(data).asInt();
-        int actual = Murmur3Hash32.hash(Slices.wrappedBuffer(data));
+        int expected = Hashing.murmur3_32_fixed().hashBytes(data.byteArray()).asInt();
+        int actual = Murmur3Hash32.hash(data);
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -37,10 +38,10 @@ public class TestMurmur3Hash32
     @RepeatedTest(100)
     public void testMoreThan4Bytes()
     {
-        byte[] data = randomBytes(131);
+        Slice data = Slices.random(131);
 
-        int expected = Hashing.murmur3_32_fixed().hashBytes(data).asInt();
-        int actual = Murmur3Hash32.hash(Slices.wrappedBuffer(data));
+        int expected = Hashing.murmur3_32_fixed().hashBytes(data.byteArray()).asInt();
+        int actual = Murmur3Hash32.hash(data);
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -48,13 +49,13 @@ public class TestMurmur3Hash32
     @RepeatedTest(100)
     public void testOffsetAndLength()
     {
-        byte[] data = randomBytes(131);
+        Slice data = Slices.random(131);
 
         int offset = 13;
         int length = 55;
 
-        int expected = Hashing.murmur3_32_fixed().hashBytes(data, offset, length).asInt();
-        int actual = Murmur3Hash32.hash(Slices.wrappedBuffer(data), offset, length);
+        int expected = Hashing.murmur3_32_fixed().hashBytes(data.byteArray(), offset, length).asInt();
+        int actual = Murmur3Hash32.hash(data, offset, length);
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -62,12 +63,12 @@ public class TestMurmur3Hash32
     @RepeatedTest(100)
     public void testNonDefaultSeed()
     {
-        byte[] data = randomBytes(131);
+        Slice data = Slices.random(131);
 
         int seed = 123456789;
 
-        int expected = Hashing.murmur3_32_fixed(seed).hashBytes(data).asInt();
-        int actual = Murmur3Hash32.hash(seed, Slices.wrappedBuffer(data), 0, data.length);
+        int expected = Hashing.murmur3_32_fixed(seed).hashBytes(data.byteArray()).asInt();
+        int actual = Murmur3Hash32.hash(seed, data, 0, data.length());
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -76,10 +77,10 @@ public class TestMurmur3Hash32
     public void testTail()
     {
         for (int i = 0; i < 4; i++) {
-            byte[] data = randomBytes(50 + i);
+            Slice data = Slices.random(50 + i);
 
-            int expected = Hashing.murmur3_32_fixed().hashBytes(data).asInt();
-            int actual = Murmur3Hash32.hash(Slices.wrappedBuffer(data));
+            int expected = Hashing.murmur3_32_fixed().hashBytes(data.byteArray()).asInt();
+            int actual = Murmur3Hash32.hash(data);
 
             assertThat(actual).isEqualTo(expected);
         }
@@ -107,12 +108,5 @@ public class TestMurmur3Hash32
         int expected = Murmur3Hash32.hash(slice);
         int actual = Murmur3Hash32.hash(value);
         assertThat(actual).isEqualTo(expected);
-    }
-
-    private static byte[] randomBytes(int length)
-    {
-        byte[] result = new byte[length];
-        ThreadLocalRandom.current().nextBytes(result);
-        return result;
     }
 }

--- a/src/test/java/io/airlift/slice/TestOutputStreamSliceOutput.java
+++ b/src/test/java/io/airlift/slice/TestOutputStreamSliceOutput.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -111,8 +110,7 @@ public class TestOutputStreamSliceOutput
     public void testEncodingBytes()
             throws Exception
     {
-        byte[] data = new byte[18000];
-        ThreadLocalRandom.current().nextBytes(data);
+        byte[] data = Slices.random(18000).byteArray();
 
         assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 0), Arrays.copyOfRange(data, 0, 0));
         assertEncoding(sliceOutput -> sliceOutput.write(data, 0, 3), Arrays.copyOfRange(data, 0, 3));
@@ -128,9 +126,8 @@ public class TestOutputStreamSliceOutput
     public void testEncodingSlice()
             throws Exception
     {
-        byte[] data = new byte[18000];
-        ThreadLocalRandom.current().nextBytes(data);
-        Slice slice = Slices.wrappedBuffer(data);
+        Slice slice = Slices.random(18000);
+        byte[] data = slice.byteArray();
 
         assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 0), Arrays.copyOfRange(data, 0, 0));
         assertEncoding(sliceOutput -> sliceOutput.writeBytes(slice, 0, 3), Arrays.copyOfRange(data, 0, 3));

--- a/src/test/java/io/airlift/slice/TestSlice.java
+++ b/src/test/java/io/airlift/slice/TestSlice.java
@@ -777,30 +777,30 @@ public class TestSlice
             throws Exception
     {
         // slightly stronger guarantees for empty slice
-        assertThat(Slices.copyOf(EMPTY_SLICE)).isSameAs(EMPTY_SLICE);
-        assertThat(Slices.copyOf(utf8Slice("hello world"), 1, 0)).isSameAs(EMPTY_SLICE);
+        assertThat(EMPTY_SLICE.copy()).isSameAs(EMPTY_SLICE);
+        assertThat(utf8Slice("hello world").copy(1, 0)).isSameAs(EMPTY_SLICE);
 
         Slice slice = utf8Slice("hello world");
-        assertThat(Slices.copyOf(slice)).isEqualTo(slice);
-        assertThat(Slices.copyOf(slice, 1, 3)).isEqualTo(slice.slice(1, 3));
+        assertThat(slice.copy()).isEqualTo(slice);
+        assertThat(slice.copy(1, 3)).isEqualTo(slice.slice(1, 3));
 
         // verify it's an actual copy
         Slice original = utf8Slice("hello world");
-        Slice copy = Slices.copyOf(original);
+        Slice copy = original.copy();
 
         original.fill((byte) 0);
         assertThat(copy).isEqualTo(utf8Slice("hello world"));
 
         // read before beginning
-        assertThatThrownBy(() -> Slices.copyOf(slice, -1, slice.length()))
+        assertThatThrownBy(() -> slice.copy(-1, slice.length()))
                 .isInstanceOf(IndexOutOfBoundsException.class);
 
         // read after end
-        assertThatThrownBy(() -> Slices.copyOf(slice, slice.length() + 1, 1))
+        assertThatThrownBy(() -> slice.copy(slice.length() + 1, 1))
                 .isInstanceOf(IndexOutOfBoundsException.class);
 
         // start before but extend past end
-        assertThatThrownBy(() -> Slices.copyOf(slice, 1, slice.length()))
+        assertThatThrownBy(() -> slice.copy(1, slice.length()))
                 .isInstanceOf(IndexOutOfBoundsException.class);
     }
 

--- a/src/test/java/io/airlift/slice/TestSliceCompactFlag.java
+++ b/src/test/java/io/airlift/slice/TestSliceCompactFlag.java
@@ -43,17 +43,17 @@ public class TestSliceCompactFlag
         assertCompact(slice.slice(0, slice.length()));
         assertThat(slice.slice(0, slice.length())).isSameAs(slice);
 
-        assertCompact(Slices.copyOf(slice));
-        assertThat(Slices.copyOf(slice).byteArray()).isNotSameAs(slice.byteArray());
-        assertCompact(Slices.copyOf(slice, 0, slice.length() - 1));
-        assertCompact(Slices.copyOf(slice, 1, slice.length() - 1));
+        assertCompact(slice.copy());
+        assertThat(slice.copy().byteArray()).isNotSameAs(slice.byteArray());
+        assertCompact(slice.copy(0, slice.length() - 1));
+        assertCompact(slice.copy(1, slice.length() - 1));
 
         Slice subSlice1 = slice.slice(0, slice.length() - 1);
         Slice subSlice2 = slice.slice(1, slice.length() - 1);
         assertNotCompact(subSlice1);
         assertNotCompact(subSlice2);
-        assertCompact(Slices.copyOf(subSlice1));
-        assertCompact(Slices.copyOf(subSlice2));
+        assertCompact(subSlice1.copy());
+        assertCompact(subSlice2.copy());
     }
 
     @Test

--- a/src/test/java/io/airlift/slice/TestSliceCompactFlag.java
+++ b/src/test/java/io/airlift/slice/TestSliceCompactFlag.java
@@ -24,7 +24,7 @@ public class TestSliceCompactFlag
     @Test
     public void testSliceConstructors()
     {
-        assertCompact(new Slice());
+        assertCompact(Slices.EMPTY_SLICE);
 
         byte[] byteArray = {(byte) 0, (byte) 1, (byte) 2, (byte) 3, (byte) 4, (byte) 5};
         assertCompact(new Slice(byteArray));

--- a/src/test/java/io/airlift/slice/TestSlices.java
+++ b/src/test/java/io/airlift/slice/TestSlices.java
@@ -122,8 +122,25 @@ public class TestSlices
     @Test
     public void testEnsureSize()
     {
-        Slice fourBytes = wrappedBuffer(new byte[] {1, 2, 3, 4});
+        Slice slice = Slices.utf8Slice("testValueAbc").slice(4, 5);
+        assertThat(slice.byteArray()).hasSize(12);
+        assertThat(slice.byteArrayOffset()).isEqualTo(4);
+        assertThat(slice.length()).isEqualTo(5);
+        assertThat(slice.toStringUtf8()).isEqualTo("Value");
 
+        // grow to a size within the existing outer slice
+        Slice newSlice = ensureSize(slice, 6);
+        // new byte array is always allocated if size changes
+        assertThat(newSlice.byteArray()).isNotSameAs(slice.byteArray());
+        // size is doubled when small
+        assertThat(newSlice.byteArray()).hasSize(10);
+        // new Slice covers the entire byte array range
+        assertThat(newSlice.byteArrayOffset()).isEqualTo(0);
+        assertThat(newSlice.length()).isEqualTo(10);
+        // the existing data outside the slice view is not copied
+        assertThat(newSlice.toStringUtf8()).isEqualTo("Value\0\0\0\0\0");
+
+        Slice fourBytes = wrappedBuffer(new byte[] {1, 2, 3, 4});
         assertThat(ensureSize(null, 42).length()).isEqualTo(42);
         assertThat(ensureSize(fourBytes, 3)).isSameAs(fourBytes);
         assertThat(ensureSize(fourBytes, 8)).isEqualTo(wrappedBuffer(new byte[] {1, 2, 3, 4, 0, 0, 0, 0}));

--- a/src/test/java/io/airlift/slice/TestSlices.java
+++ b/src/test/java/io/airlift/slice/TestSlices.java
@@ -16,6 +16,7 @@ package io.airlift.slice;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Random;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -99,6 +100,23 @@ public class TestSlices
         assertThatThrownBy(() -> allocate(Integer.MAX_VALUE - 1))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Cannot allocate slice larger than 2147483639 bytes");
+    }
+
+    @Test
+    public void testRandom()
+    {
+        assertThat(Slices.random(0)).isSameAs(EMPTY_SLICE);
+
+        Slice randomSlice = Slices.random(10);
+        assertThat(randomSlice.byteArrayOffset()).isEqualTo(0);
+        assertThat(randomSlice.length()).isEqualTo(10);
+
+        randomSlice = Slices.random(10, new Random(0));
+        assertThat(randomSlice.byteArrayOffset()).isEqualTo(0);
+        assertThat(randomSlice.length()).isEqualTo(10);
+        byte[] bytes = new byte[10];
+        new Random(0).nextBytes(bytes);
+        assertThat(randomSlice.byteArray()).isEqualTo(bytes);
     }
 
     @Test


### PR DESCRIPTION
* Move `Slices.copyOf` methods to Slice so they can easily use `Arrays.copyOfRange`.  The move isn't technically necessary, but more convenient for callers.
* Add `Slices.random` utility methods to creates slices full of random bytes.  This makes writing test for code that use Slice easier
* Add more safety to prevent creation of slices with an empty array
* Migrate `Slices.ensureSize` to `Arrays.copyOfRange`