### PR TITLE
Remove unsed Unsafe::objectFieldOffset usage in JvmUtils

### DIFF
--- a/src/main/java/io/airlift/slice/JvmUtils.java
+++ b/src/main/java/io/airlift/slice/JvmUtils.java
@@ -16,10 +16,8 @@ package io.airlift.slice;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
-import java.nio.Buffer;
 import java.nio.ByteOrder;
 
-import static io.airlift.slice.Preconditions.checkArgument;
 import static sun.misc.Unsafe.ARRAY_BOOLEAN_INDEX_SCALE;
 import static sun.misc.Unsafe.ARRAY_BYTE_INDEX_SCALE;
 import static sun.misc.Unsafe.ARRAY_DOUBLE_INDEX_SCALE;
@@ -31,7 +29,6 @@ import static sun.misc.Unsafe.ARRAY_SHORT_INDEX_SCALE;
 final class JvmUtils
 {
     static final Unsafe unsafe;
-    private static final long ADDRESS_OFFSET;
 
     static {
         if (!ByteOrder.LITTLE_ENDIAN.equals(ByteOrder.nativeOrder())) {
@@ -55,9 +52,6 @@ final class JvmUtils
             assertArrayIndexScale("Long", ARRAY_LONG_INDEX_SCALE, 8);
             assertArrayIndexScale("Float", ARRAY_FLOAT_INDEX_SCALE, 4);
             assertArrayIndexScale("Double", ARRAY_DOUBLE_INDEX_SCALE, 8);
-
-            // fetch the address field for direct buffers
-            ADDRESS_OFFSET = unsafe.objectFieldOffset(Buffer.class.getDeclaredField("address"));
         }
         catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
@@ -69,13 +63,6 @@ final class JvmUtils
         if (actualIndexScale != expectedIndexScale) {
             throw new IllegalStateException(name + " array index scale must be " + expectedIndexScale + ", but is " + actualIndexScale);
         }
-    }
-
-    static long bufferAddress(Buffer buffer)
-    {
-        checkArgument(buffer.isDirect(), "buffer is not direct");
-
-        return unsafe.getLong(buffer, ADDRESS_OFFSET);
     }
 
     private JvmUtils() {}


### PR DESCRIPTION
Prevent warnings when running on newer JDKs:

```
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by io.airlift.slice.JvmUtils (file:/Users/xxx/.m2/repository/io/airlift/slice/2.3/slice-2.3.jar)
WARNING: Please consider reporting this to the maintainers of class io.airlift.slice.JvmUtils
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```