### PR TITLE
Make Slice a record

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['17', '21']
+        java: ['25-ea']
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK ${{ matrix.java }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25-ea'
           distribution: 'temurin'
           gpg-private-key: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>160</version>
+        <version>291</version>
     </parent>
 
     <artifactId>slice</artifactId>
@@ -28,8 +28,9 @@
     <properties>
         <air.javadoc.lint>-missing</air.javadoc.lint>
         <air.test.jvmsize>3584m</air.test.jvmsize>
-        <project.build.targetJdk>17</project.build.targetJdk>
-        <air.java.version>17</air.java.version>
+        <project.build.targetJdk>25</project.build.targetJdk>
+        <air.java.version>25</air.java.version>
+        <air.compiler.enable-preview>true</air.compiler.enable-preview>
         <air.modernizer.java-version>8</air.modernizer.java-version>
         <air.check.skip-spotbugs>true</air.check.skip-spotbugs>
         <air.check.skip-pmd>true</air.check.skip-pmd>
@@ -74,6 +75,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
According to the https://github.com/openjdk/jdk/blob/5cc86738411c36378b89d8f4932a54b3089cf22e/src/hotspot/share/ci/ciField.cpp#L216 record fields are treated as trusted final, which makes them eliglble for inlining/constant folding.