### PR TITLE
Improve performance of toUpperCase and toLowerCase

### DIFF
--- a/src/main/java/io/airlift/slice/SliceUtf8.java
+++ b/src/main/java/io/airlift/slice/SliceUtf8.java
@@ -599,12 +599,34 @@ public final class SliceUtf8
 
     private static Slice toUpperCaseAsciiOrCodePoints(byte[] utf8, int utf8Offset, int utf8Length)
     {
-        Slice translated = Slices.allocate(utf8Length);
         int position = 0;
+
+        // Fast scan until the first ASCII byte that needs translation.
         while (position < utf8Length) {
             int value = utf8[utf8Offset + position] & 0xFF;
             if (value >= 0x80) {
-                return translateCodePoints(utf8, utf8Offset, utf8Length, UPPER_CODE_POINTS);
+                return translateCodePoints(utf8, utf8Offset, utf8Length, position, null, position, UPPER_CODE_POINTS);
+            }
+
+            if (value >= 'a' && value <= 'z') {
+                break;
+            }
+            position++;
+        }
+
+        // Nothing to translate in the entire input.
+        if (position == utf8Length) {
+            return Slices.wrappedBuffer(utf8, utf8Offset, utf8Length);
+        }
+
+        Slice translated = Slices.allocate(utf8Length);
+        translated.setBytes(0, utf8, utf8Offset, position);
+
+        // Continue with a single tight loop once output exists.
+        while (position < utf8Length) {
+            int value = utf8[utf8Offset + position] & 0xFF;
+            if (value >= 0x80) {
+                return translateCodePoints(utf8, utf8Offset, utf8Length, position, translated, position, UPPER_CODE_POINTS);
             }
 
             if (value >= 'a' && value <= 'z') {
@@ -615,6 +637,7 @@ public final class SliceUtf8
             }
             position++;
         }
+
         return translated;
     }
 

--- a/src/main/java/io/airlift/slice/SliceUtf8.java
+++ b/src/main/java/io/airlift/slice/SliceUtf8.java
@@ -538,6 +538,54 @@ public final class SliceUtf8
     private static Slice translateCodePoints(byte[] utf8, int utf8Offset, int utf8Length, int position, Slice translatedUtf8, int translatedPosition, int[] codePointTranslationMap)
     {
         while (position < utf8Length) {
+            int asciiStart = position;
+            while (position < utf8Length) {
+                int value = utf8[utf8Offset + position] & 0xFF;
+                if (value >= 0x80 || codePointTranslationMap[value] != value) {
+                    break;
+                }
+                position++;
+            }
+
+            if (position > asciiStart) {
+                if (translatedUtf8 != null) {
+                    int nextTranslatedPosition = translatedPosition + (position - asciiStart);
+                    if (nextTranslatedPosition > utf8Length) {
+                        translatedUtf8 = Slices.ensureSize(translatedUtf8, nextTranslatedPosition);
+                    }
+
+                    translatedUtf8.setBytes(translatedPosition, utf8, utf8Offset + asciiStart, position - asciiStart);
+                    translatedPosition = nextTranslatedPosition;
+                }
+                else if (position == utf8Length) {
+                    return Slices.wrappedBuffer(utf8, utf8Offset, utf8Length);
+                }
+            }
+
+            if (position == utf8Length) {
+                break;
+            }
+
+            int value = utf8[utf8Offset + position] & 0xFF;
+            if (value < 0x80) {
+                if (translatedUtf8 == null) {
+                    translatedUtf8 = Slices.allocate(utf8Length);
+                    translatedUtf8.setBytes(0, utf8, utf8Offset, position);
+                    translatedPosition = position;
+                }
+
+                int translatedCodePoint = codePointTranslationMap[value];
+                int nextTranslatedPosition = translatedPosition + lengthOfCodePoint(translatedCodePoint);
+                if (nextTranslatedPosition > utf8Length) {
+                    translatedUtf8 = Slices.ensureSize(translatedUtf8, nextTranslatedPosition);
+                }
+
+                setCodePointAt(translatedCodePoint, translatedUtf8, translatedPosition);
+                position++;
+                translatedPosition = nextTranslatedPosition;
+                continue;
+            }
+
             int codePoint = tryGetCodePointAtRaw(utf8, utf8Offset, utf8Length, position);
             if (codePoint >= 0) {
                 int translatedCodePoint = codePointTranslationMap[codePoint];
@@ -563,15 +611,12 @@ public final class SliceUtf8
                     translatedPosition = position;
                 }
 
-                // grow slice if necessary
                 int nextTranslatedPosition = translatedPosition + lengthOfCodePoint(translatedCodePoint);
                 if (nextTranslatedPosition > utf8Length) {
                     translatedUtf8 = Slices.ensureSize(translatedUtf8, nextTranslatedPosition);
                 }
 
-                // write translated code point
                 setCodePointAt(translatedCodePoint, translatedUtf8, translatedPosition);
-
                 position += codePointLength;
                 translatedPosition = nextTranslatedPosition;
             }

--- a/src/test/java/io/airlift/slice/SliceUtf8Benchmark.java
+++ b/src/test/java/io/airlift/slice/SliceUtf8Benchmark.java
@@ -491,7 +491,19 @@ public class SliceUtf8Benchmark
     }
 
     @Benchmark
+    public Slice benchmarkToLowerCaseTargeted(LowerCaseData data)
+    {
+        return toLowerCase(data.getUtf8(), data.getOffset(), data.getByteLength());
+    }
+
+    @Benchmark
     public Slice benchmarkToUpperCase(BenchmarkData data)
+    {
+        return toUpperCase(data.getUtf8(), data.getOffset(), data.getByteLength());
+    }
+
+    @Benchmark
+    public Slice benchmarkToUpperCaseTargeted(UpperCaseData data)
     {
         return toUpperCase(data.getUtf8(), data.getOffset(), data.getByteLength());
     }
@@ -658,6 +670,88 @@ public class SliceUtf8Benchmark
         public int getLength()
         {
             return length;
+        }
+    }
+
+    public abstract static class CaseChangeData
+    {
+        @Param({"64", "1024"})
+        private int repeatCount;
+
+        private byte[] utf8;
+        private int offset;
+        private int byteLength;
+
+        @Setup
+        public void setup()
+        {
+            byte[] input = createInput();
+            offset = 7;
+            utf8 = new byte[offset + input.length + 3];
+            System.arraycopy(input, 0, utf8, offset, input.length);
+            byteLength = input.length;
+        }
+
+        protected abstract byte[] createInput();
+
+        protected int getRepeatCount()
+        {
+            return repeatCount;
+        }
+
+        public byte[] getUtf8()
+        {
+            return utf8;
+        }
+
+        public int getOffset()
+        {
+            return offset;
+        }
+
+        public int getByteLength()
+        {
+            return byteLength;
+        }
+    }
+
+    @State(Thread)
+    public static class LowerCaseData
+            extends CaseChangeData
+    {
+        @Param({"ascii_change", "non_ascii_noop", "mixed_non_ascii_ascii_noop", "mixed_non_ascii_ascii_change"})
+        private String inputKind;
+
+        @Override
+        protected byte[] createInput()
+        {
+            return switch (inputKind) {
+                case "ascii_change" -> repeatUtf8("HELLO", getRepeatCount());
+                case "non_ascii_noop" -> repeatUtf8("ö", getRepeatCount());
+                case "mixed_non_ascii_ascii_noop" -> repeatUtf8("öhello", getRepeatCount());
+                case "mixed_non_ascii_ascii_change" -> repeatUtf8("éHELLO", getRepeatCount());
+                default -> throw new IllegalArgumentException("Unknown inputKind: " + inputKind);
+            };
+        }
+    }
+
+    @State(Thread)
+    public static class UpperCaseData
+            extends CaseChangeData
+    {
+        @Param({"ascii_change", "non_ascii_noop", "mixed_non_ascii_ascii_noop", "mixed_non_ascii_ascii_change"})
+        private String inputKind;
+
+        @Override
+        protected byte[] createInput()
+        {
+            return switch (inputKind) {
+                case "ascii_change" -> repeatUtf8("hello", getRepeatCount());
+                case "non_ascii_noop" -> repeatUtf8("Ö", getRepeatCount());
+                case "mixed_non_ascii_ascii_noop" -> repeatUtf8("ÖHELLO", getRepeatCount());
+                case "mixed_non_ascii_ascii_change" -> repeatUtf8("Éhello", getRepeatCount());
+                default -> throw new IllegalArgumentException("Unknown inputKind: " + inputKind);
+            };
         }
     }
 
@@ -1122,5 +1216,15 @@ public class SliceUtf8Benchmark
                 .build();
 
         new Runner(options).run();
+    }
+
+    private static byte[] repeatUtf8(String unit, int repeatCount)
+    {
+        byte[] encodedUnit = unit.getBytes(StandardCharsets.UTF_8);
+        DynamicSliceOutput output = new DynamicSliceOutput(encodedUnit.length * repeatCount);
+        for (int i = 0; i < repeatCount; i++) {
+            output.appendBytes(encodedUnit);
+        }
+        return output.slice().getBytes();
     }
 }

--- a/src/test/java/io/airlift/slice/TestSliceUtf8.java
+++ b/src/test/java/io/airlift/slice/TestSliceUtf8.java
@@ -721,6 +721,17 @@ public class TestSliceUtf8
         INVALID_SEQUENCES.forEach(TestSliceUtf8::assertCaseChangeWithInvalidSequence);
     }
 
+    @Test
+    public void testToUpperCaseNoOpWrapsInputRange()
+    {
+        byte[] bytes = "HELLO".getBytes(UTF_8);
+
+        Slice upper = toUpperCase(bytes, 0, bytes.length);
+        bytes[0] = 'Y';
+
+        assertThat(upper.toStringUtf8()).isEqualTo("YELLO");
+    }
+
     private static void assertCaseChangeWithInvalidSequence(byte[] invalidSequence)
     {
         assertThat(toLowerCase(wrappedBuffer(invalidSequence)))

--- a/src/test/java/io/airlift/slice/TestSliceUtf8.java
+++ b/src/test/java/io/airlift/slice/TestSliceUtf8.java
@@ -732,6 +732,20 @@ public class TestSliceUtf8
         assertThat(upper.toStringUtf8()).isEqualTo("YELLO");
     }
 
+    @Test
+    public void testCaseChangeNoOpWrapsInputRangeForNonAscii()
+    {
+        byte[] upperBytes = "Ö".getBytes(UTF_8);
+        Slice upper = toUpperCase(upperBytes, 0, upperBytes.length);
+        upperBytes[1] = (byte) 0x98;
+        assertThat(upper.toStringUtf8()).isEqualTo("Ø");
+
+        byte[] lowerBytes = "ö".getBytes(UTF_8);
+        Slice lower = toLowerCase(lowerBytes, 0, lowerBytes.length);
+        lowerBytes[1] = (byte) 0xB8;
+        assertThat(lower.toStringUtf8()).isEqualTo("ø");
+    }
+
     private static void assertCaseChangeWithInvalidSequence(byte[] invalidSequence)
     {
         assertThat(toLowerCase(wrappedBuffer(invalidSequence)))


### PR DESCRIPTION
The prior ascii fast path optimization was only applied to `toLowerCase`, and this PR extends this to `toUpperCase`.  Additionally, when there is mixed ascii and non-ascii, we can add a similar optimization where we skip the expensive per character decode for the ascii sequences.  For inputs like öhello this results in a ~50% speed up.