### PR TITLE
Speed up Slice search, UTF-8 case conversion, and trims

### DIFF
--- a/src/main/java/io/airlift/slice/BasicSliceInput.java
+++ b/src/main/java/io/airlift/slice/BasicSliceInput.java
@@ -83,7 +83,7 @@ public final class BasicSliceInput
         if (position >= slice.length()) {
             return -1;
         }
-        int result = slice.getByte(position) & 0xFF;
+        int result = slice.getByteUnchecked(position) & 0xFF;
         position++;
         return result;
     }
@@ -91,11 +91,12 @@ public final class BasicSliceInput
     @Override
     public byte readByte()
     {
-        int value = read();
-        if (value == -1) {
+        if (position >= slice.length()) {
             throw new IndexOutOfBoundsException();
         }
-        return (byte) value;
+        byte result = slice.getByteUnchecked(position);
+        position++;
+        return result;
     }
 
     @Override

--- a/src/main/java/io/airlift/slice/DynamicSliceOutput.java
+++ b/src/main/java/io/airlift/slice/DynamicSliceOutput.java
@@ -207,8 +207,12 @@ public class DynamicSliceOutput
     @Override
     public void writeZero(int length)
     {
+        if (length < 0) {
+            throw new IllegalArgumentException("length must be 0 or greater than 0.");
+        }
         slice = Slices.ensureSize(slice, size + length);
-        super.writeZero(length);
+        slice.clear(size, length);
+        size += length;
     }
 
     @Override

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -1271,14 +1271,13 @@ public final class Slice
         int offset = fromIndex;
 
         for (; offset >= 7; offset -= 8) {
-            long hasZero = match(getLongUnchecked(offset - 7), pattern);
-            while (hasZero != 0) {
-                int byteIndex = 7 - (numberOfLeadingZeros(hasZero) >>> 3);
-                int candidateIndex = (offset - 7) + byteIndex;
-                if (getByteUnchecked(candidateIndex) == b) {
-                    return candidateIndex;
-                }
-                hasZero &= ~(0x80L << (byteIndex * 8));
+            long value = getLongUnchecked(offset - 7);
+            long xor = value ^ pattern;
+            // exact zero-byte detection: the high bit is set only where the byte is zero,
+            // so the highest set bit is the last occurrence and needs no re-checking
+            long matches = ~(((xor & 0x7F7F7F7F_7F7F7F7FL) + 0x7F7F7F7F_7F7F7F7FL) | xor | 0x7F7F7F7F_7F7F7F7FL);
+            if (matches != 0) {
+                return offset - (numberOfLeadingZeros(matches) >>> 3);
             }
         }
 

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -1328,13 +1328,39 @@ public final class Slice
         }
 
         byte firstByte = pattern.getByteUnchecked(0);
+        int patternLength = pattern.length();
+
+        if (patternLength >= SIZE_OF_INT) {
+            // Anchor candidates on the first and last four bytes of the pattern, mirroring
+            // indexOf: most false candidates fail an anchor, skipping the full comparison
+            int head = pattern.getIntUnchecked(0);
+            int tailOffset = patternLength - SIZE_OF_INT;
+            int tail = pattern.getIntUnchecked(tailOffset);
+            while (index >= 0) {
+                index = lastIndexOfByte(firstByte, index);
+                if (index < 0) {
+                    break;
+                }
+
+                if (getIntUnchecked(index) == head
+                        && getIntUnchecked(index + tailOffset) == tail
+                        && equalsUnchecked(index, pattern.byteArray(), pattern.byteArrayOffset(), patternLength)) {
+                    return index;
+                }
+
+                index--;
+            }
+
+            return -1;
+        }
+
         while (index >= 0) {
             index = lastIndexOfByte(firstByte, index);
             if (index < 0) {
                 break;
             }
 
-            if (equalsUnchecked(index, pattern.byteArray(), pattern.byteArrayOffset(), pattern.length())) {
+            if (equalsUnchecked(index, pattern.byteArray(), pattern.byteArrayOffset(), patternLength)) {
                 return index;
             }
 

--- a/src/main/java/io/airlift/slice/Slice.java
+++ b/src/main/java/io/airlift/slice/Slice.java
@@ -1212,38 +1212,51 @@ public final class Slice
             return indexOfBruteForce(pattern, offset);
         }
 
-        // Using the first four bytes for faster search. We are not using eight bytes for long
-        // because we want more strings to get use of fast search.
+        int patternLength = pattern.length();
+
+        // Anchor candidates on the first and last four bytes of the pattern. Most false
+        // candidates fail an anchor, skipping the full comparison. Four-byte anchors are
+        // used so patterns as short as four bytes get the fast search.
         int head = pattern.getIntUnchecked(0);
+        int tailOffset = patternLength - SIZE_OF_INT;
+        int tail = pattern.getIntUnchecked(tailOffset);
 
-        // Take the first byte of head for faster skipping
-        int firstByteMask = head & 0xff;
-        firstByteMask |= firstByteMask << 8;
-        firstByteMask |= firstByteMask << 16;
-
-        int lastValidIndex = size - pattern.length();
+        long firstByteMask = (head & 0xFFL) * 0x01010101_01010101L;
+        int lastValidIndex = size - patternLength;
+        int scanLimit = Math.min(lastValidIndex, size - SIZE_OF_LONG);
         int index = offset;
-        while (index <= lastValidIndex) {
-            // Read four bytes in sequence
-            int value = getIntUnchecked(index);
 
-            // Compare all bytes of value with the first byte of search data
-            // see https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
-            int valueXor = value ^ firstByteMask;
-            int hasZeroBytes = (valueXor - 0x01010101) & ~valueXor & 0x80808080;
+        // Scan for occurrences of the first pattern byte, reading each window only once
+        while (index <= scanLimit) {
+            long value = getLongUnchecked(index);
+            long xor = value ^ firstByteMask;
+            // exact zero-byte detection: the high bit is set only where the byte is zero,
+            // so every candidate is a true occurrence of the first pattern byte
+            long candidates = ~(((xor & 0x7F7F7F7F_7F7F7F7FL) + 0x7F7F7F7F_7F7F7F7FL) | xor | 0x7F7F7F7F_7F7F7F7FL);
+            while (candidates != 0) {
+                int candidate = index + (numberOfTrailingZeros(candidates) >>> 3);
+                if (candidate > lastValidIndex) {
+                    return -1;
+                }
 
-            // If valueXor doesn't have any zero bytes, then there is no match and we can advance
-            if (hasZeroBytes == 0) {
-                index += SIZE_OF_INT;
-                continue;
+                if (getIntUnchecked(candidate) == head
+                        && getIntUnchecked(candidate + tailOffset) == tail
+                        && equalsUnchecked(candidate, pattern.byteArray(), pattern.byteArrayOffset(), patternLength)) {
+                    return candidate;
+                }
+
+                candidates &= candidates - 1;
             }
+            index += SIZE_OF_LONG;
+        }
 
-            // Try fast match of head and the rest
-            if (value == head && equalsUnchecked(index, pattern.byteArray(), pattern.byteArrayOffset(), pattern.length())) {
+        // Check the remaining positions when the pattern is shorter than eight bytes
+        for (; index <= lastValidIndex; index++) {
+            if (getIntUnchecked(index) == head
+                    && getIntUnchecked(index + tailOffset) == tail
+                    && equalsUnchecked(index, pattern.byteArray(), pattern.byteArrayOffset(), patternLength)) {
                 return index;
             }
-
-            index++;
         }
 
         return -1;

--- a/src/main/java/io/airlift/slice/SliceUtf8.java
+++ b/src/main/java/io/airlift/slice/SliceUtf8.java
@@ -136,6 +136,31 @@ public final class SliceUtf8
         return WHITESPACE_PAGES[codePoint >>> PAGE_SHIFT][codePoint & (PAGE_SIZE - 1)];
     }
 
+    // Runs of each ASCII whitespace byte, used to skip homogeneous whitespace stretches
+    // with the vectorized Arrays.mismatch
+    private static final byte[][] WHITESPACE_RUNS = new byte[0x21][];
+
+    static {
+        for (int value = 0; value <= 0x20; value++) {
+            if (Character.isWhitespace(value)) {
+                byte[] run = new byte[256];
+                Arrays.fill(run, (byte) value);
+                WHITESPACE_RUNS[value] = run;
+            }
+        }
+    }
+
+    // A stop bit is set in the high bit of each byte that is neither ASCII whitespace
+    // (0x09 to 0x0D, 0x1C to 0x20) nor ASCII at all. Carries from non-ASCII bytes can
+    // corrupt bits of higher lanes, but the lowest set bit is always exact, and a zero
+    // result exactly means eight bytes of ASCII whitespace.
+    private static long asciiWhitespaceStopBits(long word)
+    {
+        long controlWhitespace = (word + 0x7777_7777_7777_7777L) & ~(word + 0x7272_7272_7272_7272L); // 0x09 to 0x0D
+        long separatorOrSpace = (word + 0x6464_6464_6464_6464L) & ~(word + 0x5F5F_5F5F_5F5F_5F5FL); // 0x1C to 0x20
+        return (~(controlWhitespace | separatorOrSpace) | word) & TOP_MASK64;
+    }
+
     /**
      * Does the slice contain only 7-bit ASCII characters.
      */
@@ -957,15 +982,45 @@ public final class SliceUtf8
                     break;
                 }
                 position++;
+
+                // A run of ASCII whitespace may follow: scan it eight bytes at a time,
+                // skipping homogeneous stretches with the vectorized mismatch. A single
+                // whitespace byte before a multi-byte code point skips the scan entirely.
+                if (position >= utf8Length || utf8[utf8Offset + position] < 0) {
+                    continue;
+                }
+                while (position <= utf8Length - Long.BYTES) {
+                    long word = (long) LONG_HANDLE.get(utf8, utf8Offset + position);
+                    long stopBits = asciiWhitespaceStopBits(word);
+                    if (stopBits != 0) {
+                        position += Long.numberOfTrailingZeros(stopBits) >>> 3;
+                        break;
+                    }
+
+                    if (word == Long.rotateLeft(word, 8)) {
+                        // all eight bytes are the same whitespace, skip the whole run of it
+                        byte[] run = WHITESPACE_RUNS[(int) (word & 0xFF)];
+                        int limit = Math.min(utf8Length - position, run.length);
+                        int mismatch = Arrays.mismatch(utf8, utf8Offset + position, utf8Offset + position + limit, run, 0, limit);
+                        position += (mismatch < 0) ? limit : mismatch;
+                    }
+                    else {
+                        position += Long.BYTES;
+                    }
+                }
                 continue;
             }
 
-            int codePoint = tryGetCodePointAtRaw(utf8, utf8Offset, utf8Length, position);
-            if (codePoint < 0 || !isWhitespaceCodePoint(codePoint)) {
-                break;
-            }
+            // Consume consecutive non-ASCII whitespace code points without re-probing the
+            // fast scan, which cannot help until ASCII bytes reappear
+            while (position < utf8Length && (utf8[utf8Offset + position] & 0x80) != 0) {
+                int codePoint = tryGetCodePointAtRaw(utf8, utf8Offset, utf8Length, position);
+                if (codePoint < 0 || !isWhitespaceCodePoint(codePoint)) {
+                    return position;
+                }
 
-            position += lengthOfCodePoint(codePoint);
+                position += lengthOfCodePoint(codePoint);
+            }
         }
         return position;
     }
@@ -1086,34 +1141,49 @@ public final class SliceUtf8
                     break;
                 }
                 position--;
+
+                // A run of ASCII whitespace may precede: skip whole windows of it eight
+                // bytes at a time. A single whitespace byte after a multi-byte code point
+                // skips the scan entirely.
+                if (position <= minPosition || utf8[utf8Offset + position - 1] < 0) {
+                    continue;
+                }
+                while (position - Long.BYTES >= minPosition
+                        && asciiWhitespaceStopBits((long) LONG_HANDLE.get(utf8, utf8Offset + position - Long.BYTES)) == 0) {
+                    position -= Long.BYTES;
+                }
                 continue;
             }
 
-            // decode the code point before position if possible
-            int codePoint;
-            int codePointLength;
-            if (minPosition <= position - 2 && !isContinuationByte(utf8[utf8Offset + position - 2])) {
-                codePoint = tryGetCodePointAtRaw(utf8, utf8Offset, utf8Length, position - 2);
-                codePointLength = 2;
+            // Consume consecutive non-ASCII whitespace code points without re-probing the
+            // fast scan, which cannot help until ASCII bytes reappear
+            while (position > minPosition && (utf8[utf8Offset + position - 1] & 0x80) != 0) {
+                // decode the code point before position if possible
+                int codePoint;
+                int codePointLength;
+                if (minPosition <= position - 2 && !isContinuationByte(utf8[utf8Offset + position - 2])) {
+                    codePoint = tryGetCodePointAtRaw(utf8, utf8Offset, utf8Length, position - 2);
+                    codePointLength = 2;
+                }
+                else if (minPosition <= position - 3 && !isContinuationByte(utf8[utf8Offset + position - 3])) {
+                    codePoint = tryGetCodePointAtRaw(utf8, utf8Offset, utf8Length, position - 3);
+                    codePointLength = 3;
+                }
+                else if (minPosition <= position - 4 && !isContinuationByte(utf8[utf8Offset + position - 4])) {
+                    codePoint = tryGetCodePointAtRaw(utf8, utf8Offset, utf8Length, position - 4);
+                    codePointLength = 4;
+                }
+                else {
+                    return position;
+                }
+                if (codePoint < 0 || codePointLength != lengthOfCodePoint(codePoint)) {
+                    return position;
+                }
+                if (!isWhitespaceCodePoint(codePoint)) {
+                    return position;
+                }
+                position -= codePointLength;
             }
-            else if (minPosition <= position - 3 && !isContinuationByte(utf8[utf8Offset + position - 3])) {
-                codePoint = tryGetCodePointAtRaw(utf8, utf8Offset, utf8Length, position - 3);
-                codePointLength = 3;
-            }
-            else if (minPosition <= position - 4 && !isContinuationByte(utf8[utf8Offset + position - 4])) {
-                codePoint = tryGetCodePointAtRaw(utf8, utf8Offset, utf8Length, position - 4);
-                codePointLength = 4;
-            }
-            else {
-                break;
-            }
-            if (codePoint < 0 || codePointLength != lengthOfCodePoint(codePoint)) {
-                break;
-            }
-            if (!isWhitespaceCodePoint(codePoint)) {
-                break;
-            }
-            position -= codePointLength;
         }
         return position;
     }

--- a/src/main/java/io/airlift/slice/SliceUtf8.java
+++ b/src/main/java/io/airlift/slice/SliceUtf8.java
@@ -46,6 +46,13 @@ public final class SliceUtf8
     private static final int TOP_MASK32 = 0x8080_8080;
     private static final long TOP_MASK64 = 0x8080_8080_8080_8080L;
 
+    // Adding these to a word of ASCII bytes sets each byte's high bit according to the
+    // comparison in the constant name, e.g. adding 0x80 - 'a' sets it for bytes >= 'a'.
+    private static final long ASCII_GE_LOWER_A = 0x1F1F_1F1F_1F1F_1F1FL; // 0x80 - 'a'
+    private static final long ASCII_GT_LOWER_Z = 0x0505_0505_0505_0505L; // 0x7F - 'z'
+    private static final long ASCII_GE_UPPER_A = 0x3F3F_3F3F_3F3F_3F3FL; // 0x80 - 'A'
+    private static final long ASCII_GT_UPPER_Z = 0x2525_2525_2525_2525L; // 0x7F - 'Z'
+
     private static final int[] LOWER_CODE_POINTS;
     private static final int[] UPPER_CODE_POINTS;
     private static final int[] TITLE_CODE_POINTS;
@@ -668,60 +675,42 @@ public final class SliceUtf8
 
     private static Slice toUpperCaseAsciiOrCodePoints(byte[] utf8, int utf8Offset, int utf8Length)
     {
-        int position = 0;
-
-        // Fast scan until the first ASCII byte that needs translation.
-        while (position < utf8Length) {
-            int value = utf8[utf8Offset + position] & 0xFF;
-            if (value >= 0x80) {
-                return translateCodePoints(utf8, utf8Offset, utf8Length, position, null, position, UPPER_CODE_POINTS);
-            }
-
-            if (value >= 'a' && value <= 'z') {
-                break;
-            }
-            position++;
-        }
-
-        // Nothing to translate in the entire input.
-        if (position == utf8Length) {
-            return Slices.wrappedBuffer(utf8, utf8Offset, utf8Length);
-        }
-
-        Slice translated = Slices.allocate(utf8Length);
-        translated.setBytes(0, utf8, utf8Offset, position);
-
-        // Continue with a single tight loop once output exists.
-        while (position < utf8Length) {
-            int value = utf8[utf8Offset + position] & 0xFF;
-            if (value >= 0x80) {
-                return translateCodePoints(utf8, utf8Offset, utf8Length, position, translated, position, UPPER_CODE_POINTS);
-            }
-
-            if (value >= 'a' && value <= 'z') {
-                translated.setByteUnchecked(position, value - ('a' - 'A'));
-            }
-            else {
-                translated.setByteUnchecked(position, value);
-            }
-            position++;
-        }
-
-        return translated;
+        return translateAsciiOrCodePoints(utf8, utf8Offset, utf8Length, ASCII_GE_LOWER_A, ASCII_GT_LOWER_Z, UPPER_CODE_POINTS);
     }
 
     private static Slice toLowerCaseAsciiOrCodePoints(byte[] utf8, int utf8Offset, int utf8Length)
     {
+        return translateAsciiOrCodePoints(utf8, utf8Offset, utf8Length, ASCII_GE_UPPER_A, ASCII_GT_UPPER_Z, LOWER_CODE_POINTS);
+    }
+
+    private static Slice translateAsciiOrCodePoints(byte[] utf8, int utf8Offset, int utf8Length, long geAddend, long gtAddend, int[] codePointTranslationMap)
+    {
+        int geByteAddend = (int) (geAddend & 0xFF);
+        int gtByteAddend = (int) (gtAddend & 0xFF);
         int position = 0;
 
-        // Fast scan until the first ASCII byte that needs translation.
+        // Fast scan until the first byte that is non-ASCII or needs translation, eight bytes at a time.
+        while (position <= utf8Length - Long.BYTES) {
+            long word = (long) LONG_HANDLE.get(utf8, utf8Offset + position);
+            long caseBits = (word + geAddend) & ~(word + gtAddend) & TOP_MASK64;
+            long needsChange = (word & TOP_MASK64) | caseBits;
+            if (needsChange != 0) {
+                // Non-ASCII bytes can carry into the case bits of higher lanes, but all bits
+                // below the lowest non-ASCII byte are exact, so the lowest set bit is reliable.
+                position += Long.numberOfTrailingZeros(needsChange) >>> 3;
+                break;
+            }
+            position += Long.BYTES;
+        }
+
+        // Scan the remaining tail bytes and dispatch on the byte found by the fast scan.
         while (position < utf8Length) {
             int value = utf8[utf8Offset + position] & 0xFF;
             if (value >= 0x80) {
-                return translateCodePoints(utf8, utf8Offset, utf8Length, position, null, position, LOWER_CODE_POINTS);
+                return translateCodePoints(utf8, utf8Offset, utf8Length, position, null, position, codePointTranslationMap);
             }
 
-            if (value >= 'A' && value <= 'Z') {
+            if (((value + geByteAddend) & ~(value + gtByteAddend) & 0x80) != 0) {
                 break;
             }
             position++;
@@ -735,19 +724,27 @@ public final class SliceUtf8
         Slice translated = Slices.allocate(utf8Length);
         translated.setBytes(0, utf8, utf8Offset, position);
 
-        // Continue with a single tight loop once output exists.
+        // Translate eight ASCII bytes at a time by flipping the case bit of bytes in the range.
+        while (position <= utf8Length - Long.BYTES) {
+            long word = (long) LONG_HANDLE.get(utf8, utf8Offset + position);
+            if ((word & TOP_MASK64) != 0) {
+                return translateCodePoints(utf8, utf8Offset, utf8Length, position, translated, position, codePointTranslationMap);
+            }
+
+            long caseBits = (word + geAddend) & ~(word + gtAddend) & TOP_MASK64;
+            translated.setLongUnchecked(position, word ^ (caseBits >>> 2));
+            position += Long.BYTES;
+        }
+
+        // Translate the remaining tail bytes branchlessly.
         while (position < utf8Length) {
             int value = utf8[utf8Offset + position] & 0xFF;
             if (value >= 0x80) {
-                return translateCodePoints(utf8, utf8Offset, utf8Length, position, translated, position, LOWER_CODE_POINTS);
+                return translateCodePoints(utf8, utf8Offset, utf8Length, position, translated, position, codePointTranslationMap);
             }
 
-            if (value >= 'A' && value <= 'Z') {
-                translated.setByteUnchecked(position, value + ('a' - 'A'));
-            }
-            else {
-                translated.setByteUnchecked(position, value);
-            }
+            int caseBit = (value + geByteAddend) & ~(value + gtByteAddend) & 0x80;
+            translated.setByteUnchecked(position, value ^ (caseBit >>> 2));
             position++;
         }
 

--- a/src/main/java/io/airlift/slice/SliceUtf8.java
+++ b/src/main/java/io/airlift/slice/SliceUtf8.java
@@ -53,31 +53,74 @@ public final class SliceUtf8
     private static final long ASCII_GE_UPPER_A = 0x3F3F_3F3F_3F3F_3F3FL; // 0x80 - 'A'
     private static final long ASCII_GT_UPPER_Z = 0x2525_2525_2525_2525L; // 0x7F - 'Z'
 
-    private static final int[] LOWER_CODE_POINTS;
-    private static final int[] UPPER_CODE_POINTS;
-    private static final int[] TITLE_CODE_POINTS;
+    private static final int PAGE_SHIFT = 8;
+    private static final int PAGE_SIZE = 1 << PAGE_SHIFT;
+
+    // Case mappings are stored as per-code-point deltas in 256-entry pages indexed by the
+    // high bits of the code point. All pages without any mapping share the single zero
+    // page, keeping the tables small and cache friendly instead of a 4 MB flat array per
+    // mapping.
+    private static final int[][] LOWER_DELTA_PAGES;
+    private static final int[][] UPPER_DELTA_PAGES;
+    private static final int[][] TITLE_DELTA_PAGES;
     private static final boolean[] WHITESPACE_CODE_POINTS;
 
     static {
-        LOWER_CODE_POINTS = new int[MAX_CODE_POINT + 1];
-        UPPER_CODE_POINTS = new int[MAX_CODE_POINT + 1];
-        TITLE_CODE_POINTS = new int[MAX_CODE_POINT + 1];
+        int pageCount = (MAX_CODE_POINT + 1) >> PAGE_SHIFT;
+        LOWER_DELTA_PAGES = new int[pageCount][];
+        UPPER_DELTA_PAGES = new int[pageCount][];
+        TITLE_DELTA_PAGES = new int[pageCount][];
         WHITESPACE_CODE_POINTS = new boolean[MAX_CODE_POINT + 1];
-        for (int codePoint = 0; codePoint <= MAX_CODE_POINT; codePoint++) {
-            int type = Character.getType(codePoint);
-            if (type != Character.SURROGATE) {
-                LOWER_CODE_POINTS[codePoint] = Character.toLowerCase(codePoint);
-                UPPER_CODE_POINTS[codePoint] = Character.toUpperCase(codePoint);
-                TITLE_CODE_POINTS[codePoint] = Character.toTitleCase(codePoint);
-                WHITESPACE_CODE_POINTS[codePoint] = Character.isWhitespace(codePoint);
+
+        int[] zeroDeltas = new int[PAGE_SIZE];
+
+        for (int page = 0; page < pageCount; page++) {
+            int[] lowerDeltas = zeroDeltas;
+            int[] upperDeltas = zeroDeltas;
+            int[] titleDeltas = zeroDeltas;
+
+            int pageStart = page << PAGE_SHIFT;
+            for (int index = 0; index < PAGE_SIZE; index++) {
+                int codePoint = pageStart + index;
+                int lowerCodePoint = REPLACEMENT_CODE_POINT;
+                int upperCodePoint = REPLACEMENT_CODE_POINT;
+                int titleCodePoint = REPLACEMENT_CODE_POINT;
+                if (Character.getType(codePoint) != Character.SURROGATE) {
+                    lowerCodePoint = Character.toLowerCase(codePoint);
+                    upperCodePoint = Character.toUpperCase(codePoint);
+                    titleCodePoint = Character.toTitleCase(codePoint);
+                    WHITESPACE_CODE_POINTS[codePoint] = Character.isWhitespace(codePoint);
+                }
+
+                if (lowerCodePoint != codePoint) {
+                    if (lowerDeltas == zeroDeltas) {
+                        lowerDeltas = new int[PAGE_SIZE];
+                    }
+                    lowerDeltas[index] = lowerCodePoint - codePoint;
+                }
+                if (upperCodePoint != codePoint) {
+                    if (upperDeltas == zeroDeltas) {
+                        upperDeltas = new int[PAGE_SIZE];
+                    }
+                    upperDeltas[index] = upperCodePoint - codePoint;
+                }
+                if (titleCodePoint != codePoint) {
+                    if (titleDeltas == zeroDeltas) {
+                        titleDeltas = new int[PAGE_SIZE];
+                    }
+                    titleDeltas[index] = titleCodePoint - codePoint;
+                }
             }
-            else {
-                LOWER_CODE_POINTS[codePoint] = REPLACEMENT_CODE_POINT;
-                UPPER_CODE_POINTS[codePoint] = REPLACEMENT_CODE_POINT;
-                TITLE_CODE_POINTS[codePoint] = REPLACEMENT_CODE_POINT;
-                WHITESPACE_CODE_POINTS[codePoint] = false;
-            }
+
+            LOWER_DELTA_PAGES[page] = lowerDeltas;
+            UPPER_DELTA_PAGES[page] = upperDeltas;
+            TITLE_DELTA_PAGES[page] = titleDeltas;
         }
+    }
+
+    private static int translateCodePoint(int[][] deltaPages, int codePoint)
+    {
+        return codePoint + deltaPages[codePoint >>> PAGE_SHIFT][codePoint & (PAGE_SIZE - 1)];
     }
 
     /**
@@ -566,13 +609,14 @@ public final class SliceUtf8
         return toTitleCaseCodePoints(utf8, offset, length);
     }
 
-    private static Slice translateCodePoints(byte[] utf8, int utf8Offset, int utf8Length, int position, Slice translatedUtf8, int translatedPosition, int[] codePointTranslationMap)
+    private static Slice translateCodePoints(byte[] utf8, int utf8Offset, int utf8Length, int position, Slice translatedUtf8, int translatedPosition, int[][] codePointDeltaPages)
     {
+        int[] asciiDeltas = codePointDeltaPages[0];
         while (position < utf8Length) {
             int asciiStart = position;
             while (position < utf8Length) {
                 int value = utf8[utf8Offset + position] & 0xFF;
-                if (value >= 0x80 || codePointTranslationMap[value] != value) {
+                if (value >= 0x80 || asciiDeltas[value] != 0) {
                     break;
                 }
                 position++;
@@ -605,7 +649,7 @@ public final class SliceUtf8
                     translatedPosition = position;
                 }
 
-                int translatedCodePoint = codePointTranslationMap[value];
+                int translatedCodePoint = value + asciiDeltas[value];
                 int nextTranslatedPosition = translatedPosition + lengthOfCodePoint(translatedCodePoint);
                 if (nextTranslatedPosition > utf8Length) {
                     translatedUtf8 = Slices.ensureSize(translatedUtf8, nextTranslatedPosition);
@@ -619,7 +663,7 @@ public final class SliceUtf8
 
             int codePoint = tryGetCodePointAtRaw(utf8, utf8Offset, utf8Length, position);
             if (codePoint >= 0) {
-                int translatedCodePoint = codePointTranslationMap[codePoint];
+                int translatedCodePoint = translateCodePoint(codePointDeltaPages, codePoint);
                 int codePointLength = lengthOfCodePoint(codePoint);
 
                 if (translatedCodePoint == codePoint) {
@@ -675,15 +719,15 @@ public final class SliceUtf8
 
     private static Slice toUpperCaseAsciiOrCodePoints(byte[] utf8, int utf8Offset, int utf8Length)
     {
-        return translateAsciiOrCodePoints(utf8, utf8Offset, utf8Length, ASCII_GE_LOWER_A, ASCII_GT_LOWER_Z, UPPER_CODE_POINTS);
+        return translateAsciiOrCodePoints(utf8, utf8Offset, utf8Length, ASCII_GE_LOWER_A, ASCII_GT_LOWER_Z, UPPER_DELTA_PAGES);
     }
 
     private static Slice toLowerCaseAsciiOrCodePoints(byte[] utf8, int utf8Offset, int utf8Length)
     {
-        return translateAsciiOrCodePoints(utf8, utf8Offset, utf8Length, ASCII_GE_UPPER_A, ASCII_GT_UPPER_Z, LOWER_CODE_POINTS);
+        return translateAsciiOrCodePoints(utf8, utf8Offset, utf8Length, ASCII_GE_UPPER_A, ASCII_GT_UPPER_Z, LOWER_DELTA_PAGES);
     }
 
-    private static Slice translateAsciiOrCodePoints(byte[] utf8, int utf8Offset, int utf8Length, long geAddend, long gtAddend, int[] codePointTranslationMap)
+    private static Slice translateAsciiOrCodePoints(byte[] utf8, int utf8Offset, int utf8Length, long geAddend, long gtAddend, int[][] codePointDeltaPages)
     {
         int geByteAddend = (int) (geAddend & 0xFF);
         int gtByteAddend = (int) (gtAddend & 0xFF);
@@ -707,7 +751,7 @@ public final class SliceUtf8
         while (position < utf8Length) {
             int value = utf8[utf8Offset + position] & 0xFF;
             if (value >= 0x80) {
-                return translateCodePoints(utf8, utf8Offset, utf8Length, position, null, position, codePointTranslationMap);
+                return translateCodePoints(utf8, utf8Offset, utf8Length, position, null, position, codePointDeltaPages);
             }
 
             if (((value + geByteAddend) & ~(value + gtByteAddend) & 0x80) != 0) {
@@ -728,7 +772,7 @@ public final class SliceUtf8
         while (position <= utf8Length - Long.BYTES) {
             long word = (long) LONG_HANDLE.get(utf8, utf8Offset + position);
             if ((word & TOP_MASK64) != 0) {
-                return translateCodePoints(utf8, utf8Offset, utf8Length, position, translated, position, codePointTranslationMap);
+                return translateCodePoints(utf8, utf8Offset, utf8Length, position, translated, position, codePointDeltaPages);
             }
 
             long caseBits = (word + geAddend) & ~(word + gtAddend) & TOP_MASK64;
@@ -740,7 +784,7 @@ public final class SliceUtf8
         while (position < utf8Length) {
             int value = utf8[utf8Offset + position] & 0xFF;
             if (value >= 0x80) {
-                return translateCodePoints(utf8, utf8Offset, utf8Length, position, translated, position, codePointTranslationMap);
+                return translateCodePoints(utf8, utf8Offset, utf8Length, position, translated, position, codePointDeltaPages);
             }
 
             int caseBit = (value + geByteAddend) & ~(value + gtByteAddend) & 0x80;
@@ -787,7 +831,7 @@ public final class SliceUtf8
                 translatedCodePoint = codePoint;
             }
             else {
-                translatedCodePoint = wordStart ? TITLE_CODE_POINTS[codePoint] : LOWER_CODE_POINTS[codePoint];
+                translatedCodePoint = translateCodePoint(wordStart ? TITLE_DELTA_PAGES : LOWER_DELTA_PAGES, codePoint);
                 wordStart = false;
             }
 

--- a/src/main/java/io/airlift/slice/SliceUtf8.java
+++ b/src/main/java/io/airlift/slice/SliceUtf8.java
@@ -56,28 +56,30 @@ public final class SliceUtf8
     private static final int PAGE_SHIFT = 8;
     private static final int PAGE_SIZE = 1 << PAGE_SHIFT;
 
-    // Case mappings are stored as per-code-point deltas in 256-entry pages indexed by the
-    // high bits of the code point. All pages without any mapping share the single zero
-    // page, keeping the tables small and cache friendly instead of a 4 MB flat array per
-    // mapping.
+    // Case mappings and whitespace flags are stored in 256-entry pages indexed by the high
+    // bits of the code point. Case pages hold deltas from the code point, so all pages
+    // without any mapping share the single zero page, and whitespace pages without any
+    // whitespace share the single empty page, keeping the tables small and cache friendly.
     private static final int[][] LOWER_DELTA_PAGES;
     private static final int[][] UPPER_DELTA_PAGES;
     private static final int[][] TITLE_DELTA_PAGES;
-    private static final boolean[] WHITESPACE_CODE_POINTS;
+    private static final boolean[][] WHITESPACE_PAGES;
 
     static {
         int pageCount = (MAX_CODE_POINT + 1) >> PAGE_SHIFT;
         LOWER_DELTA_PAGES = new int[pageCount][];
         UPPER_DELTA_PAGES = new int[pageCount][];
         TITLE_DELTA_PAGES = new int[pageCount][];
-        WHITESPACE_CODE_POINTS = new boolean[MAX_CODE_POINT + 1];
+        WHITESPACE_PAGES = new boolean[pageCount][];
 
         int[] zeroDeltas = new int[PAGE_SIZE];
+        boolean[] noWhitespace = new boolean[PAGE_SIZE];
 
         for (int page = 0; page < pageCount; page++) {
             int[] lowerDeltas = zeroDeltas;
             int[] upperDeltas = zeroDeltas;
             int[] titleDeltas = zeroDeltas;
+            boolean[] whitespace = noWhitespace;
 
             int pageStart = page << PAGE_SHIFT;
             for (int index = 0; index < PAGE_SIZE; index++) {
@@ -89,7 +91,12 @@ public final class SliceUtf8
                     lowerCodePoint = Character.toLowerCase(codePoint);
                     upperCodePoint = Character.toUpperCase(codePoint);
                     titleCodePoint = Character.toTitleCase(codePoint);
-                    WHITESPACE_CODE_POINTS[codePoint] = Character.isWhitespace(codePoint);
+                    if (Character.isWhitespace(codePoint)) {
+                        if (whitespace == noWhitespace) {
+                            whitespace = new boolean[PAGE_SIZE];
+                        }
+                        whitespace[index] = true;
+                    }
                 }
 
                 if (lowerCodePoint != codePoint) {
@@ -115,12 +122,18 @@ public final class SliceUtf8
             LOWER_DELTA_PAGES[page] = lowerDeltas;
             UPPER_DELTA_PAGES[page] = upperDeltas;
             TITLE_DELTA_PAGES[page] = titleDeltas;
+            WHITESPACE_PAGES[page] = whitespace;
         }
     }
 
     private static int translateCodePoint(int[][] deltaPages, int codePoint)
     {
         return codePoint + deltaPages[codePoint >>> PAGE_SHIFT][codePoint & (PAGE_SIZE - 1)];
+    }
+
+    private static boolean isWhitespaceCodePoint(int codePoint)
+    {
+        return WHITESPACE_PAGES[codePoint >>> PAGE_SHIFT][codePoint & (PAGE_SIZE - 1)];
     }
 
     /**
@@ -826,7 +839,7 @@ public final class SliceUtf8
                 // Invalid UTF-8 sequences are copied verbatim and do not start a new word.
                 translatedCodePoint = codePoint;
             }
-            else if (WHITESPACE_CODE_POINTS[codePoint]) {
+            else if (isWhitespaceCodePoint(codePoint)) {
                 wordStart = true;
                 translatedCodePoint = codePoint;
             }
@@ -940,7 +953,7 @@ public final class SliceUtf8
         while (position < utf8Length) {
             int value = utf8[utf8Offset + position] & 0xFF;
             if (value < 0x80) {
-                if (!WHITESPACE_CODE_POINTS[value]) {
+                if (!isWhitespaceCodePoint(value)) {
                     break;
                 }
                 position++;
@@ -948,7 +961,7 @@ public final class SliceUtf8
             }
 
             int codePoint = tryGetCodePointAtRaw(utf8, utf8Offset, utf8Length, position);
-            if (codePoint < 0 || !WHITESPACE_CODE_POINTS[codePoint]) {
+            if (codePoint < 0 || !isWhitespaceCodePoint(codePoint)) {
                 break;
             }
 
@@ -1069,7 +1082,7 @@ public final class SliceUtf8
         while (minPosition < position) {
             int value = utf8[utf8Offset + position - 1] & 0xFF;
             if (value < 0x80) {
-                if (!WHITESPACE_CODE_POINTS[value]) {
+                if (!isWhitespaceCodePoint(value)) {
                     break;
                 }
                 position--;
@@ -1097,7 +1110,7 @@ public final class SliceUtf8
             if (codePoint < 0 || codePointLength != lengthOfCodePoint(codePoint)) {
                 break;
             }
-            if (!WHITESPACE_CODE_POINTS[codePoint]) {
+            if (!isWhitespaceCodePoint(codePoint)) {
                 break;
             }
             position -= codePointLength;

--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -75,8 +75,8 @@ public final class Slices
         int offset = existingSlice.byteArrayOffset();
         // copy of range can be more efficient because it avoids zeroing memory
         byte[] copy = Arrays.copyOfRange(bytes, offset, offset + newCapacity);
-        // but if the slice is a view, we need to zero the end of the array
-        Arrays.fill(copy, existingSlice.length(), bytes.length - offset, (byte) 0);
+        // but if the slice is a view, we need to zero the copied bytes beyond the view
+        Arrays.fill(copy, existingSlice.length(), Math.min(bytes.length - offset, newCapacity), (byte) 0);
         return new Slice(copy);
     }
 

--- a/src/test/java/io/airlift/slice/TestSlice.java
+++ b/src/test/java/io/airlift/slice/TestSlice.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_BYTE;
 import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
@@ -837,6 +838,48 @@ public class TestSlice
         assertIndexOf(utf8Slice("test"), utf8Slice("no"), 4, -1);
         assertIndexOf(utf8Slice("test"), utf8Slice("no"), 5, -1);
         assertIndexOf(utf8Slice("test"), utf8Slice("no"), -1, -1);
+
+        // repetitive data with dense first-byte and head-anchor candidates
+        assertIndexOf(utf8Slice("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"), utf8Slice("aaab"));
+        assertIndexOf(utf8Slice("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"), utf8Slice("aaaaaaaab"));
+        assertIndexOf(utf8Slice("abababababababababababab"), utf8Slice("ababababbb"));
+
+        // head and tail anchors match while the middle differs
+        assertIndexOf(utf8Slice("headXXXXtail-headYYYYtail"), utf8Slice("headYYYYtail"));
+
+        // first-byte occurrence too close to the end for the pattern to fit
+        assertIndexOf(utf8Slice("xxxxxxxxxxxxxxxxtes"), utf8Slice("test"));
+        assertIndexOf(utf8Slice("xxxxxxxxxxxxxxxxxxt"), utf8Slice("test"));
+    }
+
+    @Test
+    public void testIndexOfRandom()
+    {
+        Random random = new Random(42);
+        for (int iteration = 0; iteration < 5000; iteration++) {
+            byte[] data = new byte[random.nextInt(80)];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = (byte) ('a' + random.nextInt(3));
+            }
+
+            byte[] pattern = new byte[1 + random.nextInt(12)];
+            if (pattern.length <= data.length && random.nextBoolean()) {
+                // plant an existing substring so matches are common
+                System.arraycopy(data, random.nextInt(data.length - pattern.length + 1), pattern, 0, pattern.length);
+            }
+            else {
+                for (int i = 0; i < pattern.length; i++) {
+                    pattern[i] = (byte) ('a' + random.nextInt(3));
+                }
+            }
+
+            Slice dataSlice = Slices.wrappedBuffer(data);
+            Slice patternSlice = Slices.wrappedBuffer(pattern);
+
+            int expected = new String(data, UTF_8).indexOf(new String(pattern, UTF_8));
+            assertThat(dataSlice.indexOf(patternSlice)).isEqualTo(expected);
+            assertIndexOf(dataSlice, patternSlice);
+        }
     }
 
     public static void assertIndexOf(Slice data, Slice pattern, int offset, int expected)

--- a/src/test/java/io/airlift/slice/TestSlice.java
+++ b/src/test/java/io/airlift/slice/TestSlice.java
@@ -1103,6 +1103,24 @@ public class TestSlice
 
         assertThat(EMPTY_SLICE.lastIndexOfByte((byte) 'a', 0)).isEqualTo(-1);
 
+        // bytes differing only in the lowest bit after the last real match must not be matched
+        Slice tricky = utf8Slice("nnnooooooooooooooooooooo");
+        assertThat(tricky.lastIndexOfByte((byte) 'n', tricky.length() - 1)).isEqualTo(2);
+        assertThat(tricky.lastIndexOfByte((byte) 'o', tricky.length() - 1)).isEqualTo(tricky.length() - 1);
+
+        Random random = new Random(7);
+        for (int iteration = 0; iteration < 2000; iteration++) {
+            byte[] data = new byte[1 + random.nextInt(40)];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = (byte) (random.nextBoolean() ? 'n' : 'o');
+            }
+            Slice randomSlice = Slices.wrappedBuffer(data);
+            String string = new String(data, UTF_8);
+            int fromIndex = random.nextInt(data.length);
+            assertThat(randomSlice.lastIndexOfByte((byte) 'n', fromIndex)).isEqualTo(string.lastIndexOf('n', fromIndex));
+            assertThat(randomSlice.lastIndexOfByte((byte) 'o', fromIndex)).isEqualTo(string.lastIndexOf('o', fromIndex));
+        }
+
         Slice shortSlice = utf8Slice("abcdefg");
         assertThat(shortSlice.lastIndexOfByte((byte) 'a', 6)).isEqualTo(0);
         assertThat(shortSlice.lastIndexOfByte((byte) 'g', 6)).isEqualTo(6);

--- a/src/test/java/io/airlift/slice/TestSlice.java
+++ b/src/test/java/io/airlift/slice/TestSlice.java
@@ -888,6 +888,49 @@ public class TestSlice
         assertThat(data.indexOfBruteForce(pattern, offset)).isEqualTo(expected);
     }
 
+    @Test
+    public void testLastIndexOfWithAnchors()
+    {
+        // repetitive data with dense candidates
+        assertLastIndexOf(utf8Slice("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"), utf8Slice("aaab"), 28);
+        assertLastIndexOf(utf8Slice("abababababab"), utf8Slice("ababab"), 6);
+
+        // head and tail anchors match while the middle differs
+        assertLastIndexOf(utf8Slice("headXXXXtail-headYYYYtail"), utf8Slice("headXXXXtail"), 0);
+    }
+
+    @Test
+    public void testLastIndexOfRandom()
+    {
+        Random random = new Random(24);
+        for (int iteration = 0; iteration < 5000; iteration++) {
+            byte[] data = new byte[random.nextInt(80)];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = (byte) ('a' + random.nextInt(3));
+            }
+
+            byte[] pattern = new byte[1 + random.nextInt(12)];
+            if (pattern.length <= data.length && random.nextBoolean()) {
+                // plant an existing substring so matches are common
+                System.arraycopy(data, random.nextInt(data.length - pattern.length + 1), pattern, 0, pattern.length);
+            }
+            else {
+                for (int i = 0; i < pattern.length; i++) {
+                    pattern[i] = (byte) ('a' + random.nextInt(3));
+                }
+            }
+
+            Slice dataSlice = Slices.wrappedBuffer(data);
+            Slice patternSlice = Slices.wrappedBuffer(pattern);
+            String dataString = new String(data, UTF_8);
+            String patternString = new String(pattern, UTF_8);
+
+            assertThat(dataSlice.lastIndexOf(patternSlice)).isEqualTo(dataString.lastIndexOf(patternString));
+            int fromIndex = random.nextInt(data.length + 1);
+            assertThat(dataSlice.lastIndexOf(patternSlice, fromIndex)).isEqualTo(dataString.lastIndexOf(patternString, fromIndex));
+        }
+    }
+
     private static void assertLastIndexOf(Slice data, Slice pattern, int expected)
     {
         assertLastIndexOf(data, pattern, data.length(), expected);

--- a/src/test/java/io/airlift/slice/TestSliceOutput.java
+++ b/src/test/java/io/airlift/slice/TestSliceOutput.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.airlift.slice.SizeOf.instanceSize;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestSliceOutput
 {
@@ -90,6 +91,40 @@ public class TestSliceOutput
         output.appendShort(0);
         assertThat(output.getRetainedSize()).isEqualTo(originalRetainedSize);
         assertThat(output.size()).isEqualTo(10);
+    }
+
+    @Test
+    public void testWriteZero()
+    {
+        // zeroing must overwrite stale buffer content left behind by reset
+        DynamicSliceOutput output = new DynamicSliceOutput(16);
+        output.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+        output.reset();
+        output.writeByte(42);
+        output.writeZero(9);
+        output.writeByte(43);
+        byte[] expected = new byte[11];
+        expected[0] = 42;
+        expected[10] = 43;
+        assertThat(output.slice()).isEqualTo(Slices.wrappedBuffer(expected));
+
+        // zeroing across a growth boundary
+        output = new DynamicSliceOutput(4);
+        output.writeByte(7);
+        output.writeZero(1000);
+        output.writeByte(8);
+        Slice result = output.slice();
+        assertThat(result.length()).isEqualTo(1002);
+        assertThat(result.getByte(0)).isEqualTo((byte) 7);
+        assertThat(result.slice(1, 1000)).isEqualTo(Slices.allocate(1000));
+        assertThat(result.getByte(1001)).isEqualTo((byte) 8);
+
+        output = new DynamicSliceOutput(4);
+        output.writeZero(0);
+        assertThat(output.size()).isEqualTo(0);
+
+        assertThatThrownBy(() -> new DynamicSliceOutput(4).writeZero(-1))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/src/test/java/io/airlift/slice/TestSliceUtf8.java
+++ b/src/test/java/io/airlift/slice/TestSliceUtf8.java
@@ -723,6 +723,26 @@ public class TestSliceUtf8
     }
 
     @Test
+    public void testCaseChangeWordAtATime()
+    {
+        // exercise every lane of the eight-byte fast path: a case-changing, range-adjacent,
+        // or non-ASCII byte at every position within and around a word
+        for (int prefixLength = 0; prefixLength < 20; prefixLength++) {
+            String prefix = "-".repeat(prefixLength);
+            for (String interesting : ImmutableList.of("a", "z", "A", "Z", "`", "{", "@", "[", "ö", "Ö", "☃")) {
+                assertCaseChange(prefix + interesting);
+                assertCaseChange(prefix + interesting + "xYz-08_");
+            }
+        }
+
+        // long inputs: unchanged, fully translated, and switching to code points at a word boundary
+        assertCaseChange("-0189=+!?".repeat(10));
+        assertCaseChange("a".repeat(100));
+        assertCaseChange("Z".repeat(100));
+        assertCaseChange("abcdefgh".repeat(5) + "Ö" + "ABCDEFGH".repeat(5));
+    }
+
+    @Test
     public void testToUpperCaseNoOpWrapsInputRange()
     {
         byte[] bytes = "HELLO".getBytes(UTF_8);

--- a/src/test/java/io/airlift/slice/TestSliceUtf8.java
+++ b/src/test/java/io/airlift/slice/TestSliceUtf8.java
@@ -965,6 +965,37 @@ public class TestSliceUtf8
         INVALID_SEQUENCES.forEach(TestSliceUtf8::assertTrim);
     }
 
+    @Test
+    public void testTrimWordAtATime()
+    {
+        // whitespace runs of every length around the eight-byte boundaries, homogeneous
+        // and mixed, with non-ASCII whitespace and non-ASCII text
+        String[] whitespaceShapes = {" ", "\t", " \t", "\r\n", " \t\n\u000B\f\r\u001C\u001D\u001E\u001F ", "\u2028", " \u2028 "};
+        String[] bodies = {"", "x", "hello", "Öl"};
+        for (String shape : whitespaceShapes) {
+            for (int repeat = 0; repeat < 20; repeat++) {
+                String whitespace = shape.repeat(repeat);
+                for (String body : bodies) {
+                    assertTrimMatchesStrip(whitespace + body);
+                    assertTrimMatchesStrip(body + whitespace);
+                    assertTrimMatchesStrip(whitespace + body + whitespace);
+                }
+            }
+        }
+
+        // runs longer than the mismatch buffer
+        assertTrimMatchesStrip(" ".repeat(3000) + "hello" + " ".repeat(3000));
+        assertTrimMatchesStrip("\t".repeat(3000));
+    }
+
+    private static void assertTrimMatchesStrip(String string)
+    {
+        Slice slice = utf8Slice(string);
+        assertThat(leftTrim(slice).toStringUtf8()).isEqualTo(string.stripLeading());
+        assertThat(rightTrim(slice).toStringUtf8()).isEqualTo(string.stripTrailing());
+        assertThat(trim(slice).toStringUtf8()).isEqualTo(string.strip());
+    }
+
     private static void assertTrim(String string)
     {
         assertTrim(string.getBytes(UTF_8));

--- a/src/test/java/io/airlift/slice/TestSlices.java
+++ b/src/test/java/io/airlift/slice/TestSlices.java
@@ -143,6 +143,12 @@ public class TestSlices
         // the existing data outside the slice view is not copied
         assertThat(newSlice.toStringUtf8()).isEqualTo("Value\0\0\0\0\0");
 
+        // grow a view whose backing array extends beyond the new capacity
+        Slice viewOfLargerArray = Slices.utf8Slice("0123456789012345678901234567890123456789").slice(2, 3);
+        Slice grownView = ensureSize(viewOfLargerArray, 4);
+        assertThat(grownView.length()).isEqualTo(6);
+        assertThat(grownView.toStringUtf8()).isEqualTo("234\0\0\0");
+
         Slice fourBytes = wrappedBuffer(new byte[] {1, 2, 3, 4});
         assertThat(ensureSize(null, 42).length()).isEqualTo(42);
         assertThat(ensureSize(fourBytes, 3)).isSameAs(fourBytes);


### PR DESCRIPTION
A batch of performance improvements to Slice and SliceUtf8, plus one bug fix. Each commit is independent and individually benchmarked (JMH, JDK 25, Apple Silicon; multi-fork runs where single-fork variance was significant).

Bug fix

- Slices.ensureSize threw ArrayIndexOutOfBoundsException when growing a view slice whose backing array extends more than the new capacity past the view start — the tail zero-fill used a bound in the old array's coordinates. Now clamped; regression test added.

Search

- indexOf: replaced the 4-byte scan window with an 8-byte SWAR loop using exact zero-byte detection (no false-positive candidates), candidate iteration via bit tricks instead of re-reading memory, and a new tail anchor (last four pattern bytes) alongside the head anchor to reject false candidates before the full comparison. 1.2–4× faster across sparse and repetitive inputs; scan throughput ~4 → ~11 GB/s.
- lastIndexOfByte: switched to the exact zero-byte mask, eliminating the per-candidate re-check loop. 2.9× when the match sits below bytes differing only in the lowest bit (e.g. n vs o), 1.19× on plain backward scans.
- lastIndexOf: same head/tail anchors as indexOf. ~1.7× on repetitive inputs whose candidates fail deep in the pattern; unchanged on random data.

UTF-8

- ASCII case conversion (toUpperCase/toLowerCase): scans and translates eight bytes at a time by flipping the case bit of bytes in range (SWAR range test, branchless tail). 2.7–3.7× at 100 B, 5–9× at 1 KB+; the zero-copy return for already-correct input is preserved and also 8× faster to reach. Non-ASCII inputs unchanged.
- Case-mapping and whitespace tables: the four flat int[0x110000]/boolean[0x110000] arrays (≈13.7 MB of statics) become 256-entry pages where unmapped pages share a single zero/empty page — ≈160 KB total (33–36 distinct pages per case table). Trade-off: translating uniformly random non-ASCII code points measures up to 10% slower from the extra indirection; ASCII paths and trims are unchanged.
- Trims: whitespace scanning uses a SWAR stop mask over the two contiguous ASCII whitespace ranges, and the forward scan skips homogeneous runs (e.g. space padding) with vectorized Arrays.mismatch. 1.8–3.8× on ASCII whitespace at 100 B+. Trade-off: inputs of randomly interleaved multi-byte whitespace measure 4–19% slower (unpredictable run-detection branch); noted in the commit message.

I/O

- DynamicSliceOutput.writeZero: one ensureSize + one Arrays.fill instead of a writeLong(0) loop that re-entered ensureSize every eight bytes — ~2×.
- BasicSliceInput.readByte: single bounds check and unchecked read instead of routing through read()'s −1 sentinel and a second check; semantics (including the exception at end of input) unchanged.