### PR TITLE
fix: check negative capacity in Slices.allocate

### DIFF
--- a/src/main/java/io/airlift/slice/Slices.java
+++ b/src/main/java/io/airlift/slice/Slices.java
@@ -82,6 +82,9 @@ public final class Slices
 
     public static Slice allocate(int capacity)
     {
+        if (capacity < 0) {
+            throw new IllegalArgumentException("capacity is negative");
+        }
         if (capacity == 0) {
             return EMPTY_SLICE;
         }

--- a/src/test/java/io/airlift/slice/TestSlices.java
+++ b/src/test/java/io/airlift/slice/TestSlices.java
@@ -106,6 +106,14 @@ public class TestSlices
     }
 
     @Test
+    public void testNegativeAllocation()
+    {
+        assertThatThrownBy(() -> allocate(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("capacity is negative");
+    }
+
+    @Test
     public void testRandom()
     {
         assertThat(Slices.random(0)).isSameAs(EMPTY_SLICE);


### PR DESCRIPTION
## Summary

- Add a negative-capacity guard to `Slices.allocate(int)` so callers get a clear `IllegalArgumentException` instead of a raw `NegativeArraySizeException`.
- Message and exception type follow the same pattern as `ensureSize` and the existing too-large allocation check.

Fixes #170

## Test plan

- [x] Added `testNegativeAllocation` in `TestSlices.java`
- [x] `./mvnw test` passes (Java 25)